### PR TITLE
Auto-sync issue form fields to project board

### DIFF
--- a/.github/workflows/sync-form-to-project.yml
+++ b/.github/workflows/sync-form-to-project.yml
@@ -1,0 +1,181 @@
+name: "Sync Issue Form Fields to Project"
+
+# When an issue is created via a template, parse the form responses
+# from the issue body and set the corresponding project fields.
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  sync-fields:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      repository-projects: write
+    env:
+      GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+      PROJECT_ID: "PVT_kwHOCGKaWs4BTeel"
+
+    steps:
+      - name: Parse form fields and update project
+        run: |
+          ISSUE_NUMBER=${{ github.event.issue.number }}
+          ISSUE_NODE_ID=${{ github.event.issue.node_id }}
+          BODY=$(gh issue view $ISSUE_NUMBER --repo ${{ github.repository }} --json body -q .body)
+
+          # Parse Domain from form response
+          DOMAIN=$(echo "$BODY" | grep -A1 "### Domain" | tail -1 | xargs)
+          # Parse Partner Team
+          PARTNER=$(echo "$BODY" | grep -A1 "### Partner Team" | tail -1 | xargs)
+          # Parse Priority
+          PRIORITY=$(echo "$BODY" | grep -A1 "### Priority" | tail -1 | xargs)
+          # Parse Environment
+          ENVIRONMENT=$(echo "$BODY" | grep -A1 "### Environment" | tail -1 | xargs)
+          # Parse Change Risk
+          CHANGE_RISK=$(echo "$BODY" | grep -A1 "### Change Risk" | tail -1 | xargs)
+
+          echo "Domain: $DOMAIN"
+          echo "Partner Team: $PARTNER"
+          echo "Priority: $PRIORITY"
+          echo "Environment: $ENVIRONMENT"
+          echo "Change Risk: $CHANGE_RISK"
+
+          # Get the project item ID for this issue
+          ITEM_ID=$(gh api graphql -f query='
+            query($issueId: ID!) {
+              node(id: $issueId) {
+                ... on Issue {
+                  projectItems(first: 10) {
+                    nodes {
+                      id
+                      project { id }
+                    }
+                  }
+                }
+              }
+            }' -f issueId="$ISSUE_NODE_ID" --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+          # If issue isn't on the project yet, wait and retry
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue not on project yet, waiting 10s..."
+            sleep 10
+            ITEM_ID=$(gh api graphql -f query='
+              query($issueId: ID!) {
+                node(id: $issueId) {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id }
+                      }
+                    }
+                  }
+                }
+              }' -f issueId="$ISSUE_NODE_ID" --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+          fi
+
+          if [ -z "$ITEM_ID" ]; then
+            echo "Issue still not on project, skipping"
+            exit 0
+          fi
+
+          echo "Project Item ID: $ITEM_ID"
+
+          # Domain field mapping
+          declare -A DOMAIN_MAP
+          DOMAIN_MAP["Palo Alto"]="c0f75f7a"
+          DOMAIN_MAP["Illumio"]="d1fb89de"
+          DOMAIN_MAP["Cloud Network Security"]="ab3ca297"
+          DOMAIN_MAP["IaC & Automation"]="8616d5a4"
+          DOMAIN_MAP["Governance & Compliance"]="17f24626"
+          DOMAIN_MAP["Training & Enablement"]="ee4ee80e"
+          DOMAIN_MAP["General Operations"]="fe0fd490"
+
+          # Partner Team field mapping
+          declare -A PARTNER_MAP
+          PARTNER_MAP["Internal"]="a5dfe1c0"
+          PARTNER_MAP["Cloud Engineering"]="d0fa4e7f"
+          PARTNER_MAP["Platform"]="b55f42b2"
+          PARTNER_MAP["SaaS Security"]="d8eb61d9"
+          PARTNER_MAP["DBaaS"]="c741084d"
+          PARTNER_MAP["Other"]="5852d11c"
+
+          # Priority field mapping
+          declare -A PRIORITY_MAP
+          PRIORITY_MAP["Critical"]="0f0d5751"
+          PRIORITY_MAP["High"]="7d5580d8"
+          PRIORITY_MAP["Medium"]="670c54e6"
+          PRIORITY_MAP["Low"]="acc444f1"
+
+          # Environment field mapping
+          declare -A ENV_MAP
+          ENV_MAP["N/A"]="d22c9254"
+          ENV_MAP["Non-Prod"]="c524783a"
+          ENV_MAP["Prod"]="b201feab"
+
+          # Change Risk field mapping
+          declare -A RISK_MAP
+          RISK_MAP["Standard"]="d87776f4"
+          RISK_MAP["Significant"]="e44e6383"
+          RISK_MAP["Emergency"]="32c66ba5"
+
+          # Field IDs
+          DOMAIN_FIELD="PVTSSF_lAHOCGKaWs4BTeelzhAtOF8"
+          PARTNER_FIELD="PVTSSF_lAHOCGKaWs4BTeelzhAtOGA"
+          PRIORITY_FIELD="PVTSSF_lAHOCGKaWs4BTeelzhAtOGE"
+          ENV_FIELD="PVTSSF_lAHOCGKaWs4BTeelzhAtOGI"
+          RISK_FIELD="PVTSSF_lAHOCGKaWs4BTeelzhAtOGU"
+
+          # Function to update a single select field
+          update_field() {
+            local field_id=$1
+            local option_id=$2
+            local field_name=$3
+
+            if [ -n "$option_id" ]; then
+              echo "Setting $field_name to option $option_id"
+              gh api graphql -f query='
+                mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                  updateProjectV2ItemFieldValue(input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }) {
+                    projectV2Item { id }
+                  }
+                }' \
+                -f projectId="$PROJECT_ID" \
+                -f itemId="$ITEM_ID" \
+                -f fieldId="$field_id" \
+                -f optionId="$option_id"
+            fi
+          }
+
+          # Set Domain
+          if [ -n "$DOMAIN" ] && [ -n "${DOMAIN_MAP[$DOMAIN]}" ]; then
+            update_field "$DOMAIN_FIELD" "${DOMAIN_MAP[$DOMAIN]}" "Domain"
+          fi
+
+          # Set Partner Team
+          if [ -n "$PARTNER" ] && [ -n "${PARTNER_MAP[$PARTNER]}" ]; then
+            update_field "$PARTNER_FIELD" "${PARTNER_MAP[$PARTNER]}" "Partner Team"
+          fi
+
+          # Set Priority
+          if [ -n "$PRIORITY" ] && [ -n "${PRIORITY_MAP[$PRIORITY]}" ]; then
+            update_field "$PRIORITY_FIELD" "${PRIORITY_MAP[$PRIORITY]}" "Priority"
+          fi
+
+          # Set Environment
+          if [ -n "$ENVIRONMENT" ] && [ -n "${ENV_MAP[$ENVIRONMENT]}" ]; then
+            update_field "$ENV_FIELD" "${ENV_MAP[$ENVIRONMENT]}" "Environment"
+          fi
+
+          # Set Change Risk
+          if [ -n "$CHANGE_RISK" ] && [ -n "${RISK_MAP[$CHANGE_RISK]}" ]; then
+            update_field "$RISK_FIELD" "${RISK_MAP[$CHANGE_RISK]}" "Change Risk"
+          fi
+
+          echo "Done syncing fields"


### PR DESCRIPTION
Adds a GitHub Action that automatically syncs form field responses to project card fields.

**What it does:**
When an issue is created (or edited) via a template, the workflow:
1. Parses the form responses from the issue body (Domain, Partner Team, Priority, Environment, Change Risk)
2. Finds the issue on the NETSEC project board
3. Sets the corresponding project fields via GraphQL

**Why:**
Issue template forms write to the issue body, but project custom fields are separate. Without this, engineers have to manually set Domain/Partner Team/Priority on every card. This eliminates the double-entry.

**Setup required:**
Add a repo secret called `PROJECT_TOKEN` with a PAT that has `project` scope. The default GITHUB_TOKEN doesn't have project write permissions.