### PR TITLE
Install GitHub CLI for project discovery workflow

### DIFF
--- a/.github/workflows/discover-project-ids.yml
+++ b/.github/workflows/discover-project-ids.yml
@@ -27,6 +27,20 @@ jobs:
   discover:
     runs-on: ubuntu-latest
     steps:
+      - name: Install GitHub CLI
+        run: |
+          type -p curl >/dev/null || (sudo apt update && sudo apt install curl -y)
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | \
+            sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+          sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | \
+            sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+          sudo apt update
+          sudo apt install gh -y
+
+      - name: Verify GitHub CLI
+        run: gh --version
+
       - name: Discover project and field IDs
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## What this fixes
The migration discovery workflow was failing with `gh: command not found` because the runner did not have GitHub CLI installed.

## Changes
- add a GitHub CLI install step
- add a quick `gh --version` verification step

## Result
`discover-project-ids.yml` can now actually run its GraphQL discovery commands on a fresh Ubuntu runner.
