### PR TITLE
Use enterprise GitHub host for project discovery

### DIFF
--- a/.github/workflows/discover-project-ids.yml
+++ b/.github/workflows/discover-project-ids.yml
@@ -44,6 +44,7 @@ jobs:
       - name: Discover project and field IDs
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          GH_HOST: github.aexp.com
         run: |
           OWNER="${{ inputs.owner }}"
           OWNER_TYPE="${{ inputs.owner_type }}"


### PR DESCRIPTION
## What this fixes
The discovery workflow was using `gh api graphql` without an enterprise host, so it defaulted to public GitHub instead of the company GitHub Enterprise instance.

## Changes
- set `GH_HOST: github.aexp.com` for the discovery step

## Result
`gh` now targets the enterprise host instead of `api.github.com` for project discovery calls.
