### PR TITLE
Authenticate gh for enterprise project discovery

### DIFF
--- a/.github/workflows/discover-project-ids.yml
+++ b/.github/workflows/discover-project-ids.yml
@@ -41,6 +41,13 @@ jobs:
       - name: Verify GitHub CLI
         run: gh --version
 
+      - name: Authenticate GitHub CLI
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+        run: |
+          echo "$GH_TOKEN" | gh auth login --hostname github.aexp.com --with-token
+          gh auth status --hostname github.aexp.com
+
       - name: Discover project and field IDs
         env:
           GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
@@ -64,7 +71,7 @@ jobs:
           echo ""
 
           # Get project ID
-          RESULT=$(gh api graphql -f query="
+          RESULT=$(gh api graphql --hostname github.aexp.com -f query="
           {
             $QUERY_ROOT {
               projectV2(number: $PROJECT_NUM) {


### PR DESCRIPTION
## What this fixes
The enterprise-host fix got us to the right API, but `gh` still was not authenticated for the GitHub Enterprise host during the workflow run.

## Changes
- add an explicit `gh auth login --hostname github.aexp.com --with-token` step
- add `gh auth status --hostname github.aexp.com`
- make the GraphQL call use `--hostname github.aexp.com` explicitly

## Result
The discovery workflow now installs `gh`, authenticates it to the enterprise host, and then queries Projects v2 through the correct host context.
