### PR TITLE
Remove unsupported hostname flag from gh issue view

### DIFF
--- a/.github/workflows/sync-form-to-project.yml
+++ b/.github/workflows/sync-form-to-project.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           ISSUE_NUMBER=${{ github.event.issue.number }}
           ISSUE_NODE_ID=${{ github.event.issue.node_id }}
-          BODY=$(gh issue view $ISSUE_NUMBER --repo ${{ github.repository }} --hostname github.aexp.com --json body -q .body)
+          BODY=$(gh issue view $ISSUE_NUMBER --repo ${{ github.repository }} --json body -q .body)
 
           # Parse fields from form response
           # Form fields render as: ### Field Name\n\nValue


### PR DESCRIPTION
## What this fixes
`gh issue view` does not support the `--hostname` flag. The enterprise host is already provided via `GH_HOST` and the CLI auth context, so that extra flag caused the sync workflow to fail.

## Changes
- remove `--hostname github.aexp.com` from the `gh issue view` call

## Result
The workflow keeps enterprise auth/host setup, while avoiding the unsupported flag on `gh issue view`.
