### PR TITLE
Add conservative global reference scan to Panorama analyzer

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -16,14 +16,14 @@ python3 scripts/panorama_object_cleanup_candidates.py panorama.xml \
   --global-refs global_refs.csv
 ```
 
-The cleanup candidate CSV includes both `policy_reference_count` and `global_reference_count`. Treat rows with `global_reference_count > 0` as still referenced somewhere in the XML until reviewed.
+The cleanup candidate CSV includes `policy_reference_count`, `global_reference_count`, `group_membership_count`, and `delete_eligible`. Treat rows with `delete_eligible=no`, `global_reference_count > 0`, or `group_membership_count > 0` as not ready for delete until reviewed.
 
 Treat the output as review candidates, not automatic delete instructions. Validate against Panorama before removing objects.
 
 
 ## `panorama_candidates_to_delete_commands.py`
 
-Converts reviewed rows from `panorama_cleanup_candidates.csv` into Panorama CLI `delete` commands. When the candidates CSV includes `global_reference_count`, rows with non-zero global references are skipped by default.
+Converts reviewed rows from `panorama_cleanup_candidates.csv` into Panorama CLI `delete` commands. When the candidates CSV includes `global_reference_count`, `group_membership_count`, or `delete_eligible`, unsafe rows are skipped by default.
 
 Example:
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@ Operational helper scripts for cloud/network security analysis and documentation
 
 ## `panorama_object_cleanup_candidates.py`
 
-Offline, read-only analyzer for exported Palo Alto Panorama/PAN-OS XML configs. It reports likely unused address/service objects, recursively accounts for static object groups, and emits duplicate address/service value reports.
+Offline, read-only analyzer for exported Palo Alto Panorama/PAN-OS XML configs. It reports likely unused address/service objects, recursively accounts for static object groups, emits duplicate address/service value reports, and performs a conservative whole-config exact-name reference scan.
 
 Example:
 
@@ -12,20 +12,25 @@ Example:
 python3 scripts/panorama_object_cleanup_candidates.py panorama.xml \
   --csv cleanup_candidates.csv \
   --refs object_refs.csv \
-  --duplicates duplicate_values.csv
+  --duplicates duplicate_values.csv \
+  --global-refs global_refs.csv
 ```
+
+The cleanup candidate CSV includes both `policy_reference_count` and `global_reference_count`. Treat rows with `global_reference_count > 0` as still referenced somewhere in the XML until reviewed.
 
 Treat the output as review candidates, not automatic delete instructions. Validate against Panorama before removing objects.
 
 
 ## `panorama_candidates_to_delete_commands.py`
 
-Converts reviewed rows from `panorama_cleanup_candidates.csv` into Panorama CLI `delete` commands.
+Converts reviewed rows from `panorama_cleanup_candidates.csv` into Panorama CLI `delete` commands. When the candidates CSV includes `global_reference_count`, rows with non-zero global references are skipped by default.
 
 Example:
 
 ```bash
-python3 scripts/panorama_candidates_to_delete_commands.py panorama_cleanup_candidates.csv   --out delete-unused-objects.txt   --limit 500
+python3 scripts/panorama_candidates_to_delete_commands.py panorama_cleanup_candidates.csv \
+  --out delete-unused-objects.txt \
+  --limit 500
 ```
 
 Run generated commands from Panorama CLI configure mode only after review and a config snapshot. Prefer small batches with validate/commit between waves.

--- a/scripts/panorama_candidates_to_delete_commands.py
+++ b/scripts/panorama_candidates_to_delete_commands.py
@@ -9,6 +9,8 @@ This script is intentionally conservative:
   - emits DELETE commands, not SET commands
   - skips anything with non-zero policy_reference_count unless --include-referenced
   - skips anything with non-zero global_reference_count unless --include-global-referenced
+  - skips anything with group_membership_count > 0 unless --include-group-members
+  - skips rows with delete_eligible=no unless --include-ineligible
   - skips group_member_only rows unless --include-group-member-only
   - supports filtering by scope/kind
   - writes commands to a file for review/change control
@@ -61,6 +63,8 @@ def main() -> int:
     ap.add_argument("--kind", action="append", choices=sorted(SUPPORTED_KINDS), help="Only include this object kind; can repeat")
     ap.add_argument("--include-referenced", action="store_true", help="Allow rows with policy_reference_count > 0. Not recommended.")
     ap.add_argument("--include-global-referenced", action="store_true", help="Allow rows with global_reference_count > 0. Strongly not recommended.")
+    ap.add_argument("--include-group-members", action="store_true", help="Allow rows with group_membership_count > 0. Strongly not recommended.")
+    ap.add_argument("--include-ineligible", action="store_true", help="Allow rows with delete_eligible=no. Strongly not recommended.")
     ap.add_argument("--include-group-member-only", action="store_true", help="Include rows with cleanup_reason=group_member_only_no_policy_references")
     ap.add_argument("--limit", type=int, default=0, help="Max commands to emit, useful for staged batches")
     ap.add_argument("--no-commit-comment", action="store_true", help="Do not append commit/validate reminder comments")
@@ -86,6 +90,8 @@ def main() -> int:
             ref_count = int(row.get("policy_reference_count") or 0)
             # Newer analyzer CSVs include global_reference_count. Older CSVs do not; keep backward compatibility.
             global_ref_count = int(row.get("global_reference_count") or 0)
+            group_membership_count = int(row.get("group_membership_count") or 0)
+            delete_eligible = (row.get("delete_eligible") or "yes").strip().lower()
 
             if scopes and scope not in scopes:
                 skipped += 1
@@ -97,6 +103,12 @@ def main() -> int:
                 skipped += 1
                 continue
             if global_ref_count > 0 and not args.include_global_referenced:
+                skipped += 1
+                continue
+            if group_membership_count > 0 and not args.include_group_members:
+                skipped += 1
+                continue
+            if delete_eligible == "no" and not args.include_ineligible:
                 skipped += 1
                 continue
             if reason == "group_member_only_no_policy_references" and not args.include_group_member_only:

--- a/scripts/panorama_candidates_to_delete_commands.py
+++ b/scripts/panorama_candidates_to_delete_commands.py
@@ -8,6 +8,7 @@ Input is the `panorama_cleanup_candidates.csv` produced by
 This script is intentionally conservative:
   - emits DELETE commands, not SET commands
   - skips anything with non-zero policy_reference_count unless --include-referenced
+  - skips anything with non-zero global_reference_count unless --include-global-referenced
   - skips group_member_only rows unless --include-group-member-only
   - supports filtering by scope/kind
   - writes commands to a file for review/change control
@@ -59,6 +60,7 @@ def main() -> int:
     ap.add_argument("--scope", action="append", help="Only include this scope; can repeat, e.g. shared or device-group:DG1")
     ap.add_argument("--kind", action="append", choices=sorted(SUPPORTED_KINDS), help="Only include this object kind; can repeat")
     ap.add_argument("--include-referenced", action="store_true", help="Allow rows with policy_reference_count > 0. Not recommended.")
+    ap.add_argument("--include-global-referenced", action="store_true", help="Allow rows with global_reference_count > 0. Strongly not recommended.")
     ap.add_argument("--include-group-member-only", action="store_true", help="Include rows with cleanup_reason=group_member_only_no_policy_references")
     ap.add_argument("--limit", type=int, default=0, help="Max commands to emit, useful for staged batches")
     ap.add_argument("--no-commit-comment", action="store_true", help="Do not append commit/validate reminder comments")
@@ -82,6 +84,8 @@ def main() -> int:
             name = row["name"].strip()
             reason = row["cleanup_reason"].strip()
             ref_count = int(row.get("policy_reference_count") or 0)
+            # Newer analyzer CSVs include global_reference_count. Older CSVs do not; keep backward compatibility.
+            global_ref_count = int(row.get("global_reference_count") or 0)
 
             if scopes and scope not in scopes:
                 skipped += 1
@@ -90,6 +94,9 @@ def main() -> int:
                 skipped += 1
                 continue
             if ref_count > 0 and not args.include_referenced:
+                skipped += 1
+                continue
+            if global_ref_count > 0 and not args.include_global_referenced:
                 skipped += 1
                 continue
             if reason == "group_member_only_no_policy_references" and not args.include_group_member_only:

--- a/scripts/panorama_object_cleanup_candidates.py
+++ b/scripts/panorama_object_cleanup_candidates.py
@@ -457,6 +457,32 @@ def global_name_refs(root: ET.Element, parents: dict[int, ET.Element], objects: 
     return refs
 
 
+def group_membership_refs(objects: dict[ObjKey, ObjDef], dg_parents: dict[str, str]) -> dict[ObjKey, set[str]]:
+    """Map every object to groups that contain it, using scope-aware and fallback exact-name matching.
+
+    This is deliberately conservative. If a member name cannot be resolved by scope,
+    any object with that exact name is treated as a possible member reference.
+    """
+    by_name: dict[str, list[ObjKey]] = defaultdict(list)
+    for key in objects:
+        by_name[key.name].append(key)
+
+    memberships: dict[ObjKey, set[str]] = defaultdict(set)
+    for group_key, group in objects.items():
+        if group_key.kind not in GROUP_MEMBER_KINDS:
+            continue
+        fam = group_family(group_key.kind)
+        group_label = f"{group_key.scope}/{group_key.kind}/{group_key.name}"
+        for member_name in group.members:
+            resolved = resolve_name(member_name, fam, group_key.scope, objects, dg_parents)
+            if resolved:
+                memberships[resolved].add(group_label)
+                continue
+            for possible in by_name.get(member_name, []):
+                memberships[possible].add(group_label + " (unresolved-scope-fallback)")
+    return memberships
+
+
 def duplicate_value_rows(objects: dict[ObjKey, ObjDef]) -> list[dict[str, str]]:
     buckets = defaultdict(list)
     for obj in objects.values():
@@ -555,6 +581,8 @@ def main() -> int:
     for gr in global_refs:
         global_ref_counts[gr.object_key] += 1
 
+    group_memberships = group_membership_refs(objects, dg_parents)
+
     candidate_rows = []
     for key, obj in sorted(objects.items(), key=lambda kv: (kv[0].scope, kv[0].kind, kv[0].name)):
         if not args.include_groups and key.kind in GROUP_MEMBER_KINDS:
@@ -565,6 +593,14 @@ def main() -> int:
             reason = "zero_policy_references"
             if key in internal_group_refs:
                 reason = "group_member_only_no_policy_references"
+            membership_count = len(group_memberships.get(key, set()))
+            global_count = global_ref_counts[key]
+            delete_eligible = (
+                count == 0
+                and global_count == 0
+                and membership_count == 0
+                and reason == "zero_policy_references"
+            )
             candidate_rows.append({
                 "scope": key.scope,
                 "kind": key.kind,
@@ -572,8 +608,11 @@ def main() -> int:
                 "value": obj.value,
                 "policy_reference_count": str(count),
                 "direct_policy_reference_count": str(direct_count),
-                "global_reference_count": str(global_ref_counts[key]),
+                "global_reference_count": str(global_count),
+                "group_membership_count": str(membership_count),
+                "delete_eligible": "yes" if delete_eligible else "no",
                 "cleanup_reason": reason,
+                "member_of_groups": ";".join(sorted(group_memberships.get(key, set()))),
                 "description": obj.description,
                 "tags": ";".join(sorted(obj.tags)),
                 "xpath_hint": obj.xpath_hint,
@@ -611,7 +650,8 @@ def main() -> int:
 
     write_csv(args.csv, candidate_rows, [
         "scope", "kind", "name", "value", "policy_reference_count", "direct_policy_reference_count",
-        "global_reference_count", "cleanup_reason", "description", "tags", "xpath_hint",
+        "global_reference_count", "group_membership_count", "delete_eligible", "cleanup_reason", "member_of_groups",
+        "description", "tags", "xpath_hint",
     ])
     write_csv(args.refs, ref_rows, [
         "ref_scope", "rulebase", "policy_type", "rule_name", "field", "ref_name", "ref_family",

--- a/scripts/panorama_object_cleanup_candidates.py
+++ b/scripts/panorama_object_cleanup_candidates.py
@@ -92,6 +92,7 @@ class ObjDef:
     description: str = ""
     tags: set[str] = field(default_factory=set)
     xpath_hint: str = ""
+    entry_id: int = 0
 
 
 @dataclass
@@ -105,6 +106,16 @@ class Ref:
     field: str
     resolved_to: ObjKey | None
     via_group: str = ""
+
+
+@dataclass
+class GlobalRef:
+    object_key: ObjKey
+    ref_scope: str
+    ref_xpath: str
+    ref_tag: str
+    ref_text: str
+    context: str
 
 
 def strip_ns(tag: str) -> str:
@@ -213,7 +224,7 @@ def parse_objects(root: ET.Element, parents: dict[int, ET.Element]) -> dict[ObjK
             tags_node = next((c for c in list(e) if strip_ns(c.tag) == "tag"), None)
             tags = members_of(tags_node) if tags_node is not None else set()
             key = ObjKey(scope, kind, name)
-            objects[key] = ObjDef(key, value, members, desc, tags, xpath_hint(e, parents))
+            objects[key] = ObjDef(key, value, members, desc, tags, xpath_hint(e, parents), id(e))
     return objects
 
 
@@ -399,6 +410,53 @@ def collect_group_internal_refs(objects: dict[ObjKey, ObjDef], dg_parents: dict[
     return internal
 
 
+def is_within_node(node: ET.Element, ancestor_id: int, parents: dict[int, ET.Element]) -> bool:
+    cur: ET.Element | None = node
+    while cur is not None:
+        if id(cur) == ancestor_id:
+            return True
+        cur = parents.get(id(cur))
+    return False
+
+
+def global_name_refs(root: ET.Element, parents: dict[int, ET.Element], objects: dict[ObjKey, ObjDef]) -> list[GlobalRef]:
+    """Conservatively scan the entire XML for exact object-name text references.
+
+    This intentionally scans beyond known rulebases/templates/policies. It records any
+    element text exactly equal to an object name, excluding the object's own
+    definition subtree. This may include false positives, but that is safer for
+    cleanup than missing config dependencies.
+    """
+    by_name: dict[str, list[ObjKey]] = defaultdict(list)
+    for key in objects:
+        by_name[key.name].append(key)
+
+    refs: list[GlobalRef] = []
+    for node in root.iter():
+        text = (node.text or "").strip()
+        if not text or text not in by_name or text in BUILT_INS:
+            continue
+        ref_scope = get_scope_for_node(node, parents)
+        ref_tag = strip_ns(node.tag)
+        hint = xpath_hint(node, parents)
+        context_parts = []
+        cur = parents.get(id(node))
+        for _ in range(4):
+            if cur is None:
+                break
+            t = strip_ns(cur.tag)
+            n = entry_name(cur)
+            context_parts.append(f"{t}:{n}" if n else t)
+            cur = parents.get(id(cur))
+        context = " <- ".join(context_parts)
+        for key in by_name[text]:
+            obj = objects[key]
+            if obj.entry_id and is_within_node(node, obj.entry_id, parents):
+                continue
+            refs.append(GlobalRef(key, ref_scope, hint, ref_tag, text, context))
+    return refs
+
+
 def duplicate_value_rows(objects: dict[ObjKey, ObjDef]) -> list[dict[str, str]]:
     buckets = defaultdict(list)
     for obj in objects.values():
@@ -448,6 +506,7 @@ def main() -> int:
     ap.add_argument("--csv", type=Path, default=Path("panorama_cleanup_candidates.csv"), help="Object candidate CSV output")
     ap.add_argument("--refs", type=Path, default=Path("panorama_object_refs.csv"), help="Reference detail CSV output")
     ap.add_argument("--duplicates", type=Path, default=Path("panorama_duplicate_values.csv"), help="Duplicate address/service value CSV output")
+    ap.add_argument("--global-refs", type=Path, default=Path("panorama_global_refs.csv"), help="Conservative whole-config exact-name reference CSV output")
     ap.add_argument("--include-groups", action="store_true", help="Include groups in zero-policy-reference candidate output")
     args = ap.parse_args()
 
@@ -474,6 +533,8 @@ def main() -> int:
     print("expanding recursive group references...", flush=True)
     all_refs = propagate_group_refs(objects, direct_refs, dg_parents)
     internal_group_refs = collect_group_internal_refs(objects, dg_parents)
+    print("scanning whole config for exact object-name references...", flush=True)
+    global_refs = global_name_refs(root, parents, objects)
 
     policy_ref_counts = defaultdict(int)
     direct_policy_ref_counts = defaultdict(int)
@@ -489,6 +550,10 @@ def main() -> int:
     for r in direct_refs:
         if r.resolved_to:
             direct_policy_ref_counts[r.resolved_to] += 1
+
+    global_ref_counts = defaultdict(int)
+    for gr in global_refs:
+        global_ref_counts[gr.object_key] += 1
 
     candidate_rows = []
     for key, obj in sorted(objects.items(), key=lambda kv: (kv[0].scope, kv[0].kind, kv[0].name)):
@@ -507,6 +572,7 @@ def main() -> int:
                 "value": obj.value,
                 "policy_reference_count": str(count),
                 "direct_policy_reference_count": str(direct_count),
+                "global_reference_count": str(global_ref_counts[key]),
                 "cleanup_reason": reason,
                 "description": obj.description,
                 "tags": ";".join(sorted(obj.tags)),
@@ -530,10 +596,22 @@ def main() -> int:
         })
 
     dup_rows = duplicate_value_rows(objects)
+    global_ref_rows = []
+    for gr in sorted(global_refs, key=lambda x: (x.object_key.scope, x.object_key.kind, x.object_key.name, x.ref_scope, x.ref_xpath)):
+        global_ref_rows.append({
+            "scope": gr.object_key.scope,
+            "kind": gr.object_key.kind,
+            "name": gr.object_key.name,
+            "ref_scope": gr.ref_scope,
+            "ref_tag": gr.ref_tag,
+            "ref_text": gr.ref_text,
+            "context": gr.context,
+            "ref_xpath": gr.ref_xpath,
+        })
 
     write_csv(args.csv, candidate_rows, [
         "scope", "kind", "name", "value", "policy_reference_count", "direct_policy_reference_count",
-        "cleanup_reason", "description", "tags", "xpath_hint",
+        "global_reference_count", "cleanup_reason", "description", "tags", "xpath_hint",
     ])
     write_csv(args.refs, ref_rows, [
         "ref_scope", "rulebase", "policy_type", "rule_name", "field", "ref_name", "ref_family",
@@ -542,11 +620,15 @@ def main() -> int:
     write_csv(args.duplicates, dup_rows, [
         "kind", "normalized_value", "scope", "name", "raw_value", "description", "tags",
     ])
+    write_csv(args.global_refs, global_ref_rows, [
+        "scope", "kind", "name", "ref_scope", "ref_tag", "ref_text", "context", "ref_xpath",
+    ])
 
     print(f"policy refs parsed: direct={len(direct_refs)} expanded={len(all_refs)} unresolved_direct={len(unresolved)}", flush=True)
     print(f"cleanup candidates written: {args.csv.resolve()} ({len(candidate_rows)} rows)", flush=True)
     print(f"reference details written: {args.refs.resolve()} ({len(ref_rows)} rows)", flush=True)
     print(f"duplicate values written: {args.duplicates.resolve()} ({len(dup_rows)} rows)", flush=True)
+    print(f"global references written: {args.global_refs.resolve()} ({len(global_ref_rows)} rows)", flush=True)
     if unresolved:
         print("warning: unresolved object names exist in policy refs; review refs CSV for blanks", file=sys.stderr, flush=True)
     return 0


### PR DESCRIPTION
## Summary
- Add a whole-config exact object-name reference scan and write `panorama_global_refs.csv`
- Add `global_reference_count` to cleanup candidates so non-policy config references are visible
- Update delete command generator to skip rows with non-zero global refs by default while keeping backward compatibility with old candidate CSVs
- Document the new CSV/output behavior

## Validation
- `python3 -m py_compile scripts/panorama_object_cleanup_candidates.py scripts/panorama_candidates_to_delete_commands.py`
- Ran analyzer against synthetic XML containing a route-like non-policy object-name reference and verified only the truly unused object produced a delete command