### PR TITLE
Add GCP internet ingress admission ADR

### DIFF
--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -1,0 +1,322 @@
+# ADR: GCP Internet Ingress Admission Automation for Public GKE Applications
+
+| Field | Value |
+|-------|-------|
+| **Status** | Draft |
+| **Date** | 2026-06-30 |
+| **Proposed by** | Maximilian Browne |
+| **Stakeholders** | Network Security, Cloud Platform Engineering, Application Security, Application Teams, Security Leadership |
+| **Supersedes** | N/A |
+
+---
+
+## Context
+
+Public GKE applications use a multi-stage internet ingress chain that includes external edge, bot mitigation, network firewall inspection, and private GKE backend delivery.
+
+The current high-level path is:
+
+```text
+Public DNS / GTM application record
+→ Imperva
+→ Cequence SaaS bot mitigation
+→ external network load balancer (XNLB) fronting Palo Alto firewalls
+→ Palo Alto DNAT / SNAT
+→ backend GKE internal load balancer (ILB)
+→ GKE application
+```
+
+In the onboarding flow, the GTM payload points the application record at Imperva and includes origin-selection metadata. Cequence uses origin metadata, such as the X-Forwarded-Origin value from the onboarding payload, to select the correct cluster origin. The selected origin is an XNLB forwarding rule dedicated to a backend cluster or cluster group. Palo Alto policy then translates and forwards traffic to the corresponding backend GKE ILB.
+
+Today, internet firewall enablement is not just a NAT and security policy change. The internet Palo Alto firewalls also use custom URL categories to allowlist application CNAMEs one application at a time. These URL categories are referenced in rules that constrain traffic from approved Imperva / Cequence NAT IPs to the appropriate XNLB forwarding rule and backend cluster path.
+
+This creates operational friction because onboarding a new internet-facing application may require coordination across:
+
+- GTM / DNS onboarding
+- Imperva routing
+- Cequence bot-mitigation origin selection
+- XNLB forwarding rule and public IP creation
+- Palo Alto NAT and security policy
+- Palo Alto custom URL category updates
+- Vulnerability scan completion and go-live approval
+
+Security leadership has requested an automated pattern where completion of the internet application vulnerability scan can drive admission of the application into the internet ingress path.
+
+The key design decision is whether Palo Alto custom URL categories should remain the app-level admission control, or whether the edge onboarding / GTM / Cequence control plane should become the authoritative application admission gate after vulnerability scan success.
+
+## Decision
+
+We will document and evaluate two viable patterns:
+
+1. **Option A: Retain Palo Alto custom URL categories as the application-level enforcement point**
+2. **Option B: Move application admission to the GTM / Cequence onboarding control plane and remove per-app Palo Alto URL category requirements**
+
+The recommended direction is **Option B**, provided the GTM / Cequence onboarding control plane is made authoritative, auditable, reversible, and protected by clear guardrails.
+
+Option A remains a conservative fallback when Network Security requires independent firewall-level application allowlisting or when upstream admission controls are not yet mature enough to replace the Palo Alto URL-category gate.
+
+## Option A: Palo Alto URL Category as the Application Admission Gate
+
+### Description
+
+In this model, vulnerability scan success triggers an automation workflow that adds the approved application FQDN / CNAME to the correct Palo Alto custom URL category for the target cluster path.
+
+The scanner does not directly own firewall policy. Instead, scan success is treated as an input signal to a Network Security-owned ingress entitlement controller.
+
+```text
+GTM onboarding payload
+→ application / cluster / origin registry
+→ vulnerability scan result
+→ ingress entitlement controller
+→ Palo Alto custom URL category update
+→ Panorama commit / push
+→ validation through public ingress chain
+```
+
+### Traffic and Control Flow
+
+**Runtime traffic path:**
+
+```text
+User or scanner
+→ public app hostname
+→ GTM / Imperva
+→ Cequence
+→ XNLB forwarding rule
+→ Palo Alto policy with URL category match
+→ Palo Alto DNAT / SNAT
+→ GKE ILB
+→ application
+```
+
+**Automation path:**
+
+```text
+Vulnerability scan passes
+→ controller verifies FQDN, cluster, origin, forwarding rule, and policy mapping
+→ controller adds FQDN / CNAME to cluster-specific Palo Alto URL category
+→ controller commits and validates
+```
+
+### Required Source of Truth
+
+The automation must have a source-of-truth record that binds application identity to the intended ingress path.
+
+Example record:
+
+```yaml
+app_fqdn: app.example.com
+cluster_id: gke-prod-usw2-01
+origin_name: cluster-prod-usw2-01.ingress.example.net
+xnlb_forwarding_rule: fr-prod-usw2-01
+palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
+allowed_edge_sources:
+  - imperva_nat_pool_prod
+  - cequence_nat_pool_prod
+scanner_sources:
+  - appsec_scanner_public_ips
+state: requested | scanned_pass | approved | active | expired | revoked
+```
+
+### Benefits
+
+- Preserves independent firewall-level app allowlisting
+- Limits blast radius if upstream GTM / Cequence routing is misconfigured
+- Aligns with the current control model and existing Palo Alto policy structure
+- Provides an explicit NetSec-owned enforcement object for each approved application
+- Allows policy review and rollback at the firewall layer
+
+### Drawbacks
+
+- Duplicates application admission state across GTM / Cequence and Palo Alto
+- Adds manual or automated Panorama commit / push operations for each admitted application
+- Increases operational coupling between vulnerability scanning and firewall policy lifecycle
+- Requires strong naming conventions and lifecycle hygiene for URL categories
+- Can become brittle if stale CNAMEs remain in categories after application retirement
+
+### Guardrails
+
+- The vulnerability scanner must provide signed / trusted scan result events.
+- The scanner must not directly mutate Palo Alto policy or categories.
+- The entitlement controller must validate the FQDN-to-cluster mapping before modifying policy.
+- URL category changes must be logged with app owner, scan ID, commit ID, and expiration / review metadata.
+- The controller must support revocation and cleanup for retired applications.
+- Post-change validation must test the actual public ingress path.
+
+## Option B: GTM / Cequence Admission Gate with Cluster-Scoped Palo Alto Allow Rules
+
+### Description
+
+In this model, Palo Alto no longer performs per-application URL-category enforcement for the internet ingress chain. Instead, the upstream onboarding control plane becomes the application admission point.
+
+Palo Alto policy enforces the network boundary between approved edge NAT sources and cluster-specific XNLB forwarding rule destinations. Application-level admission is enforced by the GTM / Imperva / Cequence onboarding and route activation workflow.
+
+```text
+Palo Alto policy:
+source = approved Imperva / Cequence NAT pools
+destination = cluster-specific XNLB VIP / forwarding rule IP
+service = 443
+action = allow
+```
+
+Application publication is controlled upstream:
+
+```text
+GTM / onboarding record exists
+→ scanner is allowed to test application through public path
+→ vulnerability scan passes
+→ GTM / Cequence route is promoted to normal access
+→ post-admission validation confirms public ingress path
+```
+
+### Traffic and Control Flow
+
+**Pre-admission scanner path:**
+
+```text
+Application scanner public IPs
+→ public app hostname
+→ GTM / Imperva
+→ Cequence scanner-only policy or limited route
+→ XNLB
+→ Palo Alto cluster-scoped allow rule
+→ GKE ILB
+→ application
+```
+
+**Post-admission public path:**
+
+```text
+Approved public users
+→ public app hostname
+→ GTM / Imperva
+→ Cequence normal policy
+→ XNLB
+→ Palo Alto cluster-scoped allow rule
+→ GKE ILB
+→ application
+```
+
+The vulnerability scanner should generally test the same public ingress chain that users will hit. A separate private scanner path can validate application behavior earlier in CI/CD, but it does not prove the internet ingress chain is correctly configured.
+
+### Benefits
+
+- Removes duplicate per-app allowlist state from Palo Alto
+- Reduces Panorama policy/category churn during application onboarding
+- Makes application admission a responsibility of the onboarding / edge routing control plane
+- Keeps Palo Alto focused on the edge-to-cluster network security boundary
+- Simplifies operational flow for new public GKE applications
+- Better supports a pipeline-driven model where scan success promotes route state rather than firewall object membership
+
+### Drawbacks
+
+- Shifts application-level authorization away from Palo Alto and into the GTM / Cequence onboarding control plane
+- Requires strong assurance that XNLB VIPs are reachable only from approved edge NAT sources
+- Requires confidence that origin headers / route-selection metadata cannot be spoofed or abused to reach unintended clusters
+- Requires authoritative audit, rollback, and lifecycle controls in the onboarding system
+- Reduces firewall-layer app identity visibility unless logs from GTM / Imperva / Cequence are integrated into the operational view
+
+### Guardrails
+
+- GTM / Cequence route activation must be blocked until vulnerability scan success is verified.
+- Scanner-only access must be time-bounded and source-restricted.
+- XNLB forwarding rules must be cluster-scoped and mapped in source of truth.
+- Palo Alto rules must only allow approved Imperva / Cequence NAT pools to specific cluster XNLB VIPs.
+- Direct internet access to backend GKE ILBs must remain impossible.
+- Origin-selection headers and metadata must be generated only by trusted onboarding / edge components.
+- The onboarding controller must support revocation, expiration, and full audit history.
+- Post-admission synthetic validation must test the public path through GTM, Imperva, Cequence, XNLB, Palo Alto, and GKE ILB.
+
+## Scanner Path Considerations
+
+The scanner path must be explicit because it changes what the scan result proves.
+
+### Public Path Scan
+
+Recommended for final internet admission.
+
+```text
+Scanner public IPs
+→ public application hostname
+→ GTM / Imperva
+→ Cequence
+→ XNLB
+→ Palo Alto
+→ GKE ILB
+→ application
+```
+
+This validates the real exposed service and the real security chain.
+
+### Private or Separate Scanner Path
+
+Useful only for earlier pre-public application validation.
+
+```text
+Scanner network
+→ private / internal hostname
+→ internal ingress path
+→ application
+```
+
+This validates the application but does not validate the final internet ingress architecture. It should not be the only gate for public exposure.
+
+## Recommendation
+
+Proceed toward **Option B** as the target pattern if the organization is willing to make GTM / Cequence onboarding the authoritative application admission control point.
+
+Under Option B:
+
+- Palo Alto enforces cluster-scoped edge-to-origin access.
+- GTM / Cequence / onboarding automation enforces application publication state.
+- Vulnerability scan success promotes the application from scanner-only access to normal public access.
+- Post-admission validation confirms that the real public chain works.
+
+Use **Option A** when independent Palo Alto app-level allowlisting is required or while the upstream onboarding controller is not yet mature enough to be the system of record for internet application admission.
+
+## Consequences
+
+### Positive
+
+- Establishes a clear decision boundary between scanning, routing, and firewall enforcement
+- Reduces manual firewall policy work for internet-facing GKE applications if Option B is adopted
+- Preserves a conservative fallback option with Palo Alto URL categories
+- Encourages source-of-truth-driven ingress onboarding instead of ad hoc firewall updates
+
+### Negative
+
+- Option B requires stronger governance around the GTM / Cequence onboarding control plane
+- Existing Palo Alto URL category controls may need to be retired carefully to avoid visibility or audit gaps
+- Scanner-only pre-admission access must be designed carefully to avoid becoming a permanent bypass
+- The public chain remains operationally complex even if firewall category management is simplified
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|------------|--------|------------|
+| Upstream route activation becomes the only application admission gate without enough auditability | Medium | High | Require signed scan results, source-of-truth records, full audit logs, and reversible state transitions before removing Palo Alto URL categories. |
+| Scanner-only access becomes a permanent exception path | Medium | High | Time-bound scanner access, enforce scanner source IPs, and require automatic cleanup after pass/fail. |
+| Origin header or route-selection metadata is spoofed | Medium | High | Only trust metadata inserted by controlled edge/onboarding components; validate origin mapping server-side; restrict XNLB VIP access to approved edge NAT pools. |
+| Palo Alto loses useful app-level visibility | Medium | Medium | Integrate GTM / Imperva / Cequence logs with firewall logs and preserve app FQDN in centralized telemetry. |
+| Stale app records remain active after retirement | Medium | Medium | Require lifecycle state, owner metadata, expiration / review, and automated revocation. |
+| Public-path scan passes but backend mapping points to the wrong cluster | Low | High | Validate FQDN, Cequence origin, XNLB forwarding rule, Palo NAT, and GKE ILB mapping before promotion. |
+
+## Recommendation Summary
+
+| Option | Recommendation | Why |
+|--------|----------------|-----|
+| **Option A: Palo Alto URL category admission** | Conservative fallback | Maintains independent firewall app allowlisting but duplicates state and keeps onboarding operationally heavy. |
+| **Option B: GTM / Cequence admission with cluster-scoped Palo Alto rules** | Preferred target | Simplifies firewall operations and places app admission in the onboarding / edge control plane, provided strong audit and rollback controls exist. |
+
+## Open Questions
+
+- Which system is the authoritative source of truth for app FQDN to cluster origin mapping?
+- Can Cequence enforce scanner-only pre-admission access and then promote to normal access after scan pass?
+- Are Imperva / Cequence NAT pools stable and fully known for Palo Alto source restrictions?
+- Can the onboarding API safely generate and preserve the required origin metadata without allowing spoofing?
+- What telemetry will replace Palo Alto URL-category visibility if Option B is selected?
+- What is the retirement / revocation process for decommissioned public applications?
+
+## References
+
+- Existing GCP egress ADR: `./adr-gcp-internet-egress-architecture.md`

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -42,7 +42,7 @@ Keep Option A as the current enforcement model and Option B as a possible long-t
 |--------|----------------|---------|
 | **A. Automate Palo Alto URL categories** | Current enforcement model | Keep app-level allowlisting on Palo Alto, but automate category membership after scan/approval. |
 | **B. Move admission to GTM/Cequence** | Long-term candidate only | Palo allows edge NATs to cluster VIPs; GTM/Cequence controls app publication. Not safe until origin trust and source-of-truth gaps are solved. |
-| **C. NetSec internet app repo** | **Recommended near-term** | Create a NetSec-owned GitOps repo for cluster/app records and PAN-OS Terraform automation. Builds the missing source of truth incrementally. |
+| **C. NetSec internet app repo** | **Recommended near-term** | Create a NetSec-owned GitOps repo for cluster ingress bootstrap, app admission records, XNLB provisioning, and PAN-OS Terraform automation. Builds the missing source of truth incrementally. |
 
 ## Recommended Near-Term Pattern: Option C
 
@@ -56,48 +56,79 @@ netsec-internet-apps/
 └── .github/workflows/
 ```
 
-### Cluster record example
+### Cluster intent record example
+
+The platform/requestor provides the backend target details. NetSec automation allocates or returns the XNLB public IP / forwarding rule output.
 
 ```yaml
 cluster_id: gke-prod-usw2-01
 environment: prod
-origin_name: cluster-prod-usw2-01.ingress.example.net
-xnlb_forwarding_rule: fr-gke-prod-usw2-01
-xnlb_vip: 203.0.113.10
-gke_backend_ilb: 10.10.20.15
-palo_device_group: dg-internet-prod
-palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
+requestor: gke-platform-team
+backend:
+  gke_ilb_ip: 10.10.20.15
+  gke_ilb_name: ilb-gke-prod-usw2-01
+  gcp_project: app-prod-host-project
+netsec_ingress:
+  xnlb_forwarding_rule: fr-gke-prod-usw2-01   # created by NetSec repo
+  xnlb_vip: allocated_by_terraform           # output, not requester-selected
+  palo_device_group: dg-internet-prod
+  palo_nat_rule: nat-gke-prod-usw2-01
+  palo_security_rule: allow-edge-to-gke-prod-usw2-01
+  palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
 allowed_edge_sources:
   - imperva_prod_nat
   - cequence_prod_nat
-state: active
+gtm_onboarding_output:
+  origin_ip: terraform_output
+  origin_name: optional_generated_name
+state: requested | provisioned | active | deprecated | retired
 ```
 
-### App record example
+### App admission record example
+
+Apps bind to an already-provisioned cluster ingress path. Phase 1 updates the cluster-specific Palo Alto URL category; scan status can start as metadata/manual evidence and later become detective/remediation automation.
 
 ```yaml
 fqdn: app.example.com
 owner: application-team
 environment: prod
 target_cluster: gke-prod-usw2-01
-scan_status: passed
-scan_id: scan-12345
-state: active
+palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
+admission:
+  state: requested | approved | active | revoked
+  approval: netsec-approved
+scan:
+  mode: detective_remediation
+  status: not_started | passed | failed | waived
+  scan_id: null
 ```
 
 ### Flow
 
+**Cluster bootstrap:**
+
 ```text
-App onboarding request
-→ PR adds/updates app record
-→ CI validates target cluster, metadata, scan/waiver, and policy constraints
-→ Terraform plan shows PAN-OS URL category / policy changes
-→ NetSec review + approval
-→ Terraform apply updates Palo Alto
-→ post-change validation confirms public path
+Platform builds GKE cluster + backend ILB
+→ Platform submits cluster intent with backend ILB details
+→ NetSec repo provisions XNLB VIP/forwarding rule
+→ NetSec repo provisions Palo NAT/security/category mapping
+→ workflow outputs XNLB origin IP/name for GTM onboarding
+→ requestor uses that output in GTM onboarding API payload
 ```
 
-Phase 1 should focus on codifying the current Palo Alto URL category workflow. Later phases can add scanner webhooks, remediation actions, expiration, revocation, and broader edge-control integration.
+**App onboarding:**
+
+```text
+App onboarding request
+→ PR adds/updates app record targeting an existing cluster record
+→ CI validates target cluster, metadata, approval/scan/waiver state, and policy constraints
+→ Terraform plan shows Palo Alto URL category membership change
+→ NetSec review + approval
+→ Terraform apply updates Palo Alto
+→ scanner/validation tests real public path after exposure unless scanner-only pre-admission exists
+```
+
+Phase 1 should focus on cluster ingress bootstrap and the current Palo Alto URL category workflow. Later phases can add scanner webhooks, remediation actions, expiration, revocation, and broader edge-control integration.
 
 ## Why Not Start With Option B?
 
@@ -151,10 +182,10 @@ For new internet-capable GKE clusters, the repository can own the cluster ingres
 
 ```text
 1. Platform builds GKE cluster and backend GKE ILB.
-2. Platform opens/merges a cluster intent record with backend ILB details.
-3. NetSec repo provisions or records the XNLB forwarding rule and reserved public IP.
+2. Platform submits a cluster intent record with backend ILB details.
+3. NetSec repo provisions the XNLB forwarding rule and reserved public IP.
 4. NetSec repo provisions/updates Palo Alto NAT, security policy, and cluster URL category.
-5. Workflow outputs the cluster origin information required for GTM onboarding.
+5. Workflow outputs the XNLB origin IP/name required for GTM onboarding.
 6. Requestor submits GTM onboarding API payload using the NetSec-provided origin/IP details.
 7. App records can then add CNAME/FQDN membership for that cluster path.
 ```
@@ -166,7 +197,7 @@ Important boundary: requestors can provide the backend GKE ILB because that is t
 | Phase | Goal | Output |
 |-------|------|--------|
 | **0. Discovery** | Confirm owners and capability gaps | Owner map + capability matrix |
-| **1. Cluster ingress bootstrap** | Create/register internet-capable cluster ingress path | `clusters/*.yaml`, XNLB forwarding rule/public IP, Palo NAT/security/category mapping, GTM origin output |
+| **1. Cluster ingress bootstrap** | Create/register internet-capable cluster ingress path | `clusters/*.yaml`, backend ILB input, XNLB forwarding rule/public IP output, Palo NAT/security/category mapping, GTM onboarding output |
 | **2. App registration** | Track app-to-cluster admission intent | `apps/*.yaml` records |
 | **3. PAN-OS automation** | Automate current Palo URL category process | Terraform-managed category membership |
 | **4. Scanner integration** | Add scan pass/waiver as a repo gate | CI/webhook/remediation workflow |
@@ -177,7 +208,7 @@ Important boundary: requestors can provide the backend GKE ILB because that is t
 - Can existing Palo Alto URL categories and rules be safely imported into Terraform state?
 - What exact GCP permissions/project boundaries are required for the NetSec repo to provision XNLB forwarding rules and reserve public IPs?
 - What output format should the NetSec workflow provide to the requestor for the follow-on GTM onboarding API payload?
-- Who owns cluster registration when new internet-capable GKE clusters are created?
+- What exact handoff does Platform use to submit the post-build cluster intent record?
 - If no scanner-only pre-admission path exists, should scan integration be detective/remediation first rather than preventative?
 - What SLA/action should occur when a newly exposed app fails scan: notify only, block future changes, remove Palo URL category membership, or require manual exception?
 - Can Imperva/Cequence enforce scanner-only pre-admission access per app in the future?

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -1,297 +1,62 @@
-# ADR: GCP Internet Ingress Admission Automation for Public GKE Applications
+# ADR: GCP Internet Ingress Automation for Public GKE Applications
 
 | Field | Value |
 |-------|-------|
 | **Status** | Draft |
 | **Date** | 2026-06-30 |
 | **Proposed by** | Maximilian Browne |
-| **Stakeholders** | Network Security, Cloud Platform Engineering, Application Security, Application Teams, Security Leadership |
-| **Supersedes** | N/A |
+| **Stakeholders** | Network Security, Cloud Platform, AppSec, Edge/WAF/Bot, App Teams, Security Leadership |
 
 ---
 
 ## Context
 
-Public GKE applications use a multi-stage internet ingress chain that includes external edge, bot mitigation, network firewall inspection, and private GKE backend delivery.
-
-The current high-level path is:
+Public GKE application ingress currently follows this chain:
 
 ```text
-Public DNS / GTM application record
+Public DNS / GTM app record
 → Imperva
 → Cequence SaaS bot mitigation
-→ external network load balancer (XNLB) fronting Palo Alto firewalls
+→ external NLB (XNLB) fronting Palo Alto firewalls
 → Palo Alto DNAT / SNAT
-→ backend GKE internal load balancer (ILB)
+→ backend GKE internal load balancer
 → GKE application
 ```
 
-In the onboarding flow, the GTM payload points the application record at Imperva and includes origin-selection metadata. Cequence uses origin metadata, such as the X-Forwarded-Origin value from the onboarding payload, to select the correct cluster origin. The selected origin is an XNLB forwarding rule dedicated to a backend cluster or cluster group. Palo Alto policy then translates and forwards traffic to the corresponding backend GKE ILB.
+Current onboarding has two major manual pain points:
 
-Today, internet firewall enablement is not just a NAT and security policy change. The internet Palo Alto firewalls also use custom URL categories to allowlist application CNAMEs one application at a time. These URL categories are referenced in rules that constrain traffic from approved Imperva / Cequence NAT IPs to the appropriate XNLB forwarding rule and backend cluster path.
+1. **New internet-capable GKE clusters require XNLB / public IP / Palo Alto mapping work**, and NetSec may not have a clear signal when that work is needed.
+2. **Each new app requires adding the app CNAME/FQDN to the Palo Alto custom URL category for the target cluster path.**
 
-This creates operational friction because onboarding a new internet-facing application may require coordination across:
+Security leadership also wants vulnerability scan completion to become part of internet app admission.
 
-- GTM / DNS onboarding
-- Imperva routing
-- Cequence bot-mitigation origin selection
-- XNLB forwarding rule and public IP creation
-- Palo Alto NAT and security policy
-- Palo Alto custom URL category updates
-- Vulnerability scan completion and go-live approval
-
-Security leadership has requested an automated pattern where completion of the internet application vulnerability scan can drive admission of the application into the internet ingress path.
-
-The key design decision is whether Palo Alto custom URL categories should remain the app-level admission control, or whether the edge onboarding / GTM / Cequence control plane should become the authoritative application admission gate after vulnerability scan success.
+This is not just a scanner-to-firewall integration. It is an internet ingress lifecycle problem across GTM/DDI, Imperva, Cequence, Palo Alto, GKE platform, AppSec scanning, and observability.
 
 ## Decision
 
-We will document and evaluate two viable patterns:
+Use **Option C: Network Security Internet Application Repository** as the near-term automation path.
 
-1. **Option A: Retain Palo Alto custom URL categories as the application-level enforcement point**
-2. **Option B: Move application admission to the GTM / Cequence onboarding control plane and remove per-app Palo Alto URL category requirements**
-3. **Option C: Create a Network Security-owned internet application repository as the transitional control plane**
+Keep Option A as the current enforcement model and Option B as a possible long-term target.
 
-The recommended near-term direction is **Option C** because it codifies the controls Network Security owns today while creating the missing source-of-truth layer needed for either longer-term option.
+| Option | Recommendation | Summary |
+|--------|----------------|---------|
+| **A. Automate Palo Alto URL categories** | Current enforcement model | Keep app-level allowlisting on Palo Alto, but automate category membership after scan/approval. |
+| **B. Move admission to GTM/Cequence** | Long-term candidate only | Palo allows edge NATs to cluster VIPs; GTM/Cequence controls app publication. Not safe until origin trust and source-of-truth gaps are solved. |
+| **C. NetSec internet app repo** | **Recommended near-term** | Create a NetSec-owned GitOps repo for cluster/app records and PAN-OS Terraform automation. Builds the missing source of truth incrementally. |
 
-Option B remains the cleaner long-term target if the GTM / Cequence onboarding control plane becomes authoritative, auditable, reversible, and protected by clear guardrails.
+## Recommended Near-Term Pattern: Option C
 
-Option A remains a conservative implementation model when Network Security requires independent firewall-level application allowlisting or when upstream admission controls are not yet mature enough to replace the Palo Alto URL-category gate.
-
-## Option A: Palo Alto URL Category as the Application Admission Gate
-
-### Description
-
-In this model, vulnerability scan success triggers an automation workflow that adds the approved application FQDN / CNAME to the correct Palo Alto custom URL category for the target cluster path.
-
-The scanner does not directly own firewall policy. Instead, scan success is treated as an input signal to a Network Security-owned ingress entitlement controller.
-
-```text
-GTM onboarding payload
-→ application / cluster / origin registry
-→ vulnerability scan result
-→ ingress entitlement controller
-→ Palo Alto custom URL category update
-→ Panorama commit / push
-→ validation through public ingress chain
-```
-
-### Traffic and Control Flow
-
-**Runtime traffic path:**
-
-```text
-User or scanner
-→ public app hostname
-→ GTM / Imperva
-→ Cequence
-→ XNLB forwarding rule
-→ Palo Alto policy with URL category match
-→ Palo Alto DNAT / SNAT
-→ GKE ILB
-→ application
-```
-
-**Automation path:**
-
-```text
-Vulnerability scan passes
-→ controller verifies FQDN, cluster, origin, forwarding rule, and policy mapping
-→ controller adds FQDN / CNAME to cluster-specific Palo Alto URL category
-→ controller commits and validates
-```
-
-### Required Source of Truth
-
-The automation must have a source-of-truth record that binds application identity to the intended ingress path.
-
-Example record:
-
-```yaml
-app_fqdn: app.example.com
-cluster_id: gke-prod-usw2-01
-origin_name: cluster-prod-usw2-01.ingress.example.net
-xnlb_forwarding_rule: fr-prod-usw2-01
-palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
-allowed_edge_sources:
-  - imperva_nat_pool_prod
-  - cequence_nat_pool_prod
-scanner_sources:
-  - appsec_scanner_public_ips
-state: requested | scanned_pass | approved | active | expired | revoked
-```
-
-
-### Assumptions to Validate
-
-This option assumes the organization can safely automate Palo Alto URL category updates without making the vulnerability scanner a direct firewall policy authority.
-
-| Assumption | Validation Question | Why It Matters |
-|------------|---------------------|----------------|
-| A Network Security-owned controller can update Panorama objects safely | Is there an approved API path for adding/removing FQDNs from custom URL categories and committing/pushing changes? | Without this, Option A remains manual or requires brittle automation around firewall operations. |
-| The scanner emits trustworthy pass/fail events | Are scan result webhooks signed, tied to a scan ID, and bound to the exact application FQDN/onboarding request? | Scan success becomes a condition for internet exposure; replayed or ambiguous scan events cannot be accepted. |
-| A source of truth can map app FQDN to the correct firewall object | Can automation resolve `app FQDN -> cluster/origin -> XNLB forwarding rule -> Palo URL category` deterministically? | Prevents the controller from adding the right app to the wrong cluster/category path. |
-| Palo Alto URL category matching is the intended app-level control | Does the policy actually evaluate the hostname/category in the expected traffic leg, and does TLS/SNI/HTTP visibility support that match? | If the firewall cannot reliably evaluate the app identity, URL categories provide false confidence. |
-| Panorama commit/push latency is acceptable for onboarding | How long does an object update and commit/push take, and what happens on partial failure? | Each app promotion depends on firewall control-plane timing and failure handling. |
-| URL category lifecycle can be managed | Can automation remove entries on app retirement, failed scans, expiration, or revocation? | Otherwise categories become stale allowlists. |
-| Post-change validation can prove the public path | Can a synthetic probe confirm `FQDN -> Imperva -> Cequence -> XNLB -> Palo -> GKE ILB` after the category update? | Prevents policy success from being mistaken for end-to-end application reachability. |
-
-### Benefits
-
-- Preserves independent firewall-level app allowlisting
-- Limits blast radius if upstream GTM / Cequence routing is misconfigured
-- Aligns with the current control model and existing Palo Alto policy structure
-- Provides an explicit NetSec-owned enforcement object for each approved application
-- Allows policy review and rollback at the firewall layer
-
-### Drawbacks
-
-- Duplicates application admission state across GTM / Cequence and Palo Alto
-- Adds manual or automated Panorama commit / push operations for each admitted application
-- Increases operational coupling between vulnerability scanning and firewall policy lifecycle
-- Requires strong naming conventions and lifecycle hygiene for URL categories
-- Can become brittle if stale CNAMEs remain in categories after application retirement
-
-### Guardrails
-
-- The vulnerability scanner must provide signed / trusted scan result events.
-- The scanner must not directly mutate Palo Alto policy or categories.
-- The entitlement controller must validate the FQDN-to-cluster mapping before modifying policy.
-- URL category changes must be logged with app owner, scan ID, commit ID, and expiration / review metadata.
-- The controller must support revocation and cleanup for retired applications.
-- Post-change validation must test the actual public ingress path.
-
-## Option B: GTM / Cequence Admission Gate with Cluster-Scoped Palo Alto Allow Rules
-
-### Description
-
-In this model, Palo Alto no longer performs per-application URL-category enforcement for the internet ingress chain. Instead, the upstream onboarding control plane becomes the application admission point.
-
-Palo Alto policy enforces the network boundary between approved edge NAT sources and cluster-specific XNLB forwarding rule destinations. Application-level admission is enforced by the GTM / Imperva / Cequence onboarding and route activation workflow.
-
-```text
-Palo Alto policy:
-source = approved Imperva / Cequence NAT pools
-destination = cluster-specific XNLB VIP / forwarding rule IP
-service = 443
-action = allow
-```
-
-Application publication is controlled upstream:
-
-```text
-GTM / onboarding record exists
-→ scanner is allowed to test application through public path
-→ vulnerability scan passes
-→ GTM / Cequence route is promoted to normal access
-→ post-admission validation confirms public ingress path
-```
-
-### Traffic and Control Flow
-
-**Pre-admission scanner path:**
-
-```text
-Application scanner public IPs
-→ public app hostname
-→ GTM / Imperva
-→ Cequence scanner-only policy or limited route
-→ XNLB
-→ Palo Alto cluster-scoped allow rule
-→ GKE ILB
-→ application
-```
-
-**Post-admission public path:**
-
-```text
-Approved public users
-→ public app hostname
-→ GTM / Imperva
-→ Cequence normal policy
-→ XNLB
-→ Palo Alto cluster-scoped allow rule
-→ GKE ILB
-→ application
-```
-
-The vulnerability scanner should generally test the same public ingress chain that users will hit. A separate private scanner path can validate application behavior earlier in CI/CD, but it does not prove the internet ingress chain is correctly configured.
-
-
-### Assumptions to Validate
-
-This option assumes the edge/onboarding control plane can become the authoritative application admission point, while Palo Alto policy is simplified to cluster-scoped edge-to-origin enforcement.
-
-| Assumption | Validation Question | Why It Matters |
-|------------|---------------------|----------------|
-| GTM / Imperva / Cequence can support a staged application route | Can an app hostname exist in `scanner_only` state before being promoted to normal public access? | Without staged route state, scan-before-general-access is difficult or requires temporary firewall exceptions. |
-| The scanner can test the real public hostname | Can the scanner target `https://app.example.com` through GTM, Imperva, Cequence, XNLB, Palo Alto, and GKE ILB? | A scan against a private/bypass path does not validate the production internet chain. |
-| Scanner-only access can be restricted per app | Can Imperva/Cequence allow only scanner public IPs for one app without opening other apps on the same cluster origin? | Prevents scanner pre-admission access from becoming broad cluster exposure. |
-| Cequence can enforce app-level admission reliably | Can Cequence distinguish app hostnames and promote/revoke a single app without impacting other apps on the same origin? | Option B removes Palo URL categories, so app-level admission must move upstream. |
-| Origin selection metadata is trusted and non-spoofable | Is the X-Forwarded-Origin/origin-selection value inserted or overwritten only by trusted systems? What happens if a client sends its own value? | If clients can influence origin selection, traffic could be routed to unintended clusters. Current understanding: clients may already be able to set X-Forwarded-Origin to an FQDN or IP, so this assumption is not currently validated and may be false. |
-| The onboarding system is a real source of truth | Does an authoritative record exist for `app FQDN -> owner -> environment -> cluster -> origin -> XNLB forwarding rule -> lifecycle state`? | The scanner result only says the app passed; it does not know where the app is allowed to route. Current understanding: no official source of record exists today, so this is a major workstream for Option B. |
-| Palo Alto can be safely reduced to cluster-scoped policy | Are Imperva/Cequence NAT pools stable and complete, and are XNLB VIPs reachable only from those approved sources? | Palo becomes the edge-to-cluster boundary instead of per-app admission control. |
-| App identity remains visible outside Palo Alto URL categories | Can logs from GTM, Imperva, Cequence, Palo Alto, and GKE be correlated by FQDN/app ID? | Removing URL categories should not create an audit/forensics blind spot. |
-| Promotion and rollback are first-class state transitions | Can automation move `scanner_only -> active -> revoked` cleanly and quickly? | Internet exposure must be reversible without emergency manual edits. |
-
-### Benefits
-
-- Removes duplicate per-app allowlist state from Palo Alto
-- Reduces Panorama policy/category churn during application onboarding
-- Makes application admission a responsibility of the onboarding / edge routing control plane
-- Keeps Palo Alto focused on the edge-to-cluster network security boundary
-- Simplifies operational flow for new public GKE applications
-- Better supports a pipeline-driven model where scan success promotes route state rather than firewall object membership
-
-### Drawbacks
-
-- Shifts application-level authorization away from Palo Alto and into the GTM / Cequence onboarding control plane
-- Requires strong assurance that XNLB VIPs are reachable only from approved edge NAT sources
-- Requires confidence that origin headers / route-selection metadata cannot be spoofed or abused to reach unintended clusters
-- Requires authoritative audit, rollback, and lifecycle controls in the onboarding system
-- Reduces firewall-layer app identity visibility unless logs from GTM / Imperva / Cequence are integrated into the operational view
-
-### Guardrails
-
-- GTM / Cequence route activation must be blocked until vulnerability scan success is verified.
-- Scanner-only access must be time-bounded and source-restricted.
-- XNLB forwarding rules must be cluster-scoped and mapped in source of truth.
-- Palo Alto rules must only allow approved Imperva / Cequence NAT pools to specific cluster XNLB VIPs.
-- Direct internet access to backend GKE ILBs must remain impossible.
-- Origin-selection headers and metadata must be generated only by trusted onboarding / edge components.
-- The onboarding controller must support revocation, expiration, and full audit history.
-- Post-admission synthetic validation must test the public path through GTM, Imperva, Cequence, XNLB, Palo Alto, and GKE ILB.
-
-
-## Option C: Network Security Internet Application Repository
-
-### Description
-
-In this model, Network Security creates a dedicated repository that acts as the near-term control plane for internet-facing GKE application admission and firewall-side implementation.
-
-The repository codifies the cluster and application records that are currently implicit or spread across teams. It can use Terraform and the PAN-OS provider to manage the firewall-side controls that Network Security owns today, while optionally referencing or provisioning related cloud-side objects when ownership is clarified.
-
-Example repository structure:
+Create a repository such as:
 
 ```text
 netsec-internet-apps/
 ├── clusters/
-│   ├── gke-prod-usw2-01.yaml
-│   └── gke-prod-use1-01.yaml
 ├── apps/
-│   ├── app.example.com.yaml
-│   └── payments.example.com.yaml
 ├── terraform/
-│   ├── panos-url-categories/
-│   ├── panos-security-policy/
-│   └── panos-nat-policy/
 └── .github/workflows/
-    ├── validate-app.yml
-    ├── plan-panos.yml
-    └── apply-panos.yml
 ```
 
-Example cluster record:
+### Cluster record example
 
 ```yaml
 cluster_id: gke-prod-usw2-01
@@ -308,7 +73,7 @@ allowed_edge_sources:
 state: active
 ```
 
-Example application record:
+### App record example
 
 ```yaml
 fqdn: app.example.com
@@ -318,334 +83,73 @@ target_cluster: gke-prod-usw2-01
 scan_status: passed
 scan_id: scan-12345
 state: active
-expires_at: null
 ```
 
-### Traffic and Control Flow
-
-The runtime traffic path is the same as the current architecture:
-
-```text
-User or scanner
-→ public app hostname
-→ GTM / Imperva
-→ Cequence
-→ XNLB forwarding rule
-→ Palo Alto policy / NAT
-→ GKE ILB
-→ application
-```
-
-The control flow changes from manual requests to pull requests:
+### Flow
 
 ```text
 App onboarding request
-→ PR adds or updates apps/app.example.com.yaml
-→ CI validates target cluster, required metadata, scan state, naming, and policy constraints
-→ Terraform plan shows Palo Alto URL category / policy / NAT changes
-→ approval and merge
-→ Terraform apply updates PAN-OS objects
+→ PR adds/updates app record
+→ CI validates target cluster, metadata, scan/waiver, and policy constraints
+→ Terraform plan shows PAN-OS URL category / policy changes
+→ NetSec review + approval
+→ Terraform apply updates Palo Alto
 → post-change validation confirms public path
 ```
 
-Phase 1 should focus on codifying the current Palo Alto URL category process. Later phases can add scanner webhooks, remediation actions, expiration, revocation, and broader edge-control integration.
-
-### Assumptions to Validate
-
-This option assumes Network Security can own a repository-backed interface for the firewall-side and admission-record portions of internet app onboarding, even if other teams continue owning GTM, DDI, Imperva, Cequence, and GKE platform primitives.
-
-| Assumption | Validation Question | Why It Matters |
-|------------|---------------------|----------------|
-| Network Security can own the repo and review process | Is NetSec allowed to be the code owner for app-to-cluster firewall admission records and PAN-OS changes? | Without clear ownership, the repo becomes another unofficial spreadsheet with YAML cosplay. |
-| PAN-OS provider can manage required objects safely | Can Terraform manage custom URL categories, security rules, NAT rules, device groups, and commit/push behavior for the target Panorama/Palo Alto environment? | The repo is only useful if it can reliably implement the firewall-side changes. |
-| Existing Palo Alto state can be imported or reconciled | Can current URL categories, NAT rules, and security policies be imported into Terraform state or represented without destructive drift? | Prevents the first apply from becoming a change-management jump scare. |
-| XNLB forwarding rule ownership is clear | Does NetSec create XNLB VIPs/forwarding rules, or does the repo only reference cluster records created by the GKE/platform team? | Determines whether the repository provisions cloud-side ingress objects or only validates references. |
-| Cluster registration data can be supplied reliably | Who creates the cluster record when a new internet-capable GKE cluster is created? | Solves the current problem where new XNLB/cluster ingress capacity is not evident to NetSec. |
-| App records can require scan/approval metadata | Can CI enforce scan status, scan ID, waiver, owner, environment, and target cluster before allowing a merge? | Allows vulnerability scanning to become a policy gate without requiring direct scanner-to-firewall writes. |
-| Scanner integration can start asynchronous | Can the first version accept scan metadata manually or by PR comment/status, then later integrate webhooks? | Avoids blocking Phase 1 on a full multi-team scanner integration. |
-| Apply permissions and approvals are acceptable | Who can merge, who can apply, and is there a separation between requesters, approvers, and automation credentials? | Prevents app teams from self-approving internet exposure. |
-| Rollback and revocation can be represented as code | Can removing or changing an app record remove the CNAME/category entry and trigger validation? | The repo must handle decommissioning, not only onboarding. |
-| Secrets and provider credentials can be managed securely | Where will Panorama credentials, API keys, and GitHub Actions secrets live, and who can access them? | The automation should not create a new privileged secret sprawl problem. |
-| Change windows and commit timing are compatible with GitOps | Are Panorama commits/pushes allowed from CI, and do they need scheduled windows or manual gates? | Determines whether this can be fully automated or must remain plan-and-approve. |
-| Multi-team dependencies can be represented but not owned | Can the repo validate external prerequisites without pretending to own GTM, DDI, Imperva, Cequence, or scanner systems? | Keeps Phase 1 scoped to NetSec-owned controls instead of turning into a 13-team platform rewrite. |
-
-### Benefits
-
-- Creates the missing source-of-truth layer incrementally
-- Gives Network Security an auditable, reviewable, PR-based workflow for current manual firewall work
-- Reduces immediate toil around Palo Alto URL category membership
-- Supports naming conventions, validation, ownership metadata, scan metadata, and lifecycle state
-- Does not require GTM / Cequence to become a mature admission controller on day one
-- Provides a migration bridge toward Option B if edge-control capabilities mature later
-
-### Drawbacks
-
-- Still relies on Palo Alto URL categories during the transitional phase
-- Adds a new repository and GitOps workflow to operate
-- Requires Terraform state ownership and careful import/reconciliation of existing PAN-OS objects
-- Does not by itself solve GTM, DDI, Imperva, Cequence, or scanner ownership gaps
-- Could become the long-term source of truth by accident if a broader platform owner never emerges
-
-### Guardrails
-
-- Treat the repository as the source of truth for NetSec-owned admission records and firewall-side implementation only.
-- Require CODEOWNERS review from Network Security for production changes.
-- Require app owner, environment, target cluster, scan status or waiver, and lifecycle state on every app record.
-- Run CI validation before plan/apply.
-- Use plan review before production apply, at least during initial rollout.
-- Import or reconcile existing PAN-OS objects before enabling writes.
-- Do not allow app teams to bypass approval by editing app records directly.
-- Log every apply with PR number, approver, commit SHA, Terraform plan, and Panorama commit ID.
-- Keep GTM/DDI/Imperva/Cequence ownership explicit; do not silently make the NetSec repo responsible for systems it cannot enforce.
-
-## Scanner Path Considerations
-
-The scanner path must be explicit because it changes what the scan result proves.
-
-### Public Path Scan
-
-Recommended for final internet admission.
-
-```text
-Scanner public IPs
-→ public application hostname
-→ GTM / Imperva
-→ Cequence
-→ XNLB
-→ Palo Alto
-→ GKE ILB
-→ application
-```
-
-This validates the real exposed service and the real security chain.
-
-### Private or Separate Scanner Path
-
-Useful only for earlier pre-public application validation.
-
-```text
-Scanner network
-→ private / internal hostname
-→ internal ingress path
-→ application
-```
-
-This validates the application but does not validate the final internet ingress architecture. It should not be the only gate for public exposure.
-
-
-## Capability Discovery Required Before Selection
-
-Before selecting either option, the stakeholder teams should validate the following high-ticket capabilities. These are gating assumptions, not implementation details.
-
-| Capability | Owner to Confirm | Option A Dependency | Option B Dependency |
-|------------|------------------|---------------------|---------------------|
-| Scanner can scan the public application FQDN through the real internet ingress chain | Application Security / Scanner Team | Required for final validation | Required for final admission |
-| Scanner results are signed/trustworthy and tied to a specific onboarding request | Application Security / Platform | Required | Required |
-| GTM / Imperva / Cequence can create scanner-only pre-admission access per app | Edge / WAF / Bot Teams | Helpful | Required |
-| Cequence origin selection is deterministic and protected from client spoofing | Cequence / Edge Team | Required to validate path | Required for admission control; currently suspected false if clients can set X-Forwarded-Origin directly |
-| Source-of-truth mapping exists for app FQDN to cluster/origin/XNLB | Platform / DDI / Edge / NetSec | Required for correct category updates | Required for route promotion; currently no official source of record is known |
-| Palo Alto API automation can update URL categories and commit/push safely | Network Security | Required | Not required for app admission |
-| Palo Alto policy can be safely scoped to edge NAT pools and cluster XNLB VIPs | Network Security | Useful | Required |
-| Telemetry can correlate app FQDN across GTM, Imperva, Cequence, Palo Alto, and GKE | SecOps / Observability | Required | Required, especially if URL categories are removed |
-| Revocation/expiration can disable public exposure per app | Platform / Edge / NetSec | Required | Required |
-
-If the staged edge route, origin trust, scanner public-path testing, or onboarding source of truth cannot be validated, Option B should not be selected as the immediate target. In that case, Option A is the safer transitional automation pattern because Palo Alto remains an independent application-level enforcement point.
-
-
-## Current Known Gaps
-
-The following gaps are known or suspected as of this draft and should be treated as primary discussion points with stakeholder teams:
-
-- **Origin header trust is not established.** Current understanding is that clients can set `X-Forwarded-Origin` directly to an FQDN or IP. If true, origin selection cannot be treated as a trusted admission signal unless the edge chain overwrites, strips, signs, or otherwise validates this value before Cequence uses it.
-- **No official onboarding source of record is known.** There does not appear to be a single authoritative system that binds app FQDN, owner, environment, cluster, origin, XNLB forwarding rule, Palo Alto policy/category, scan state, and lifecycle state. Without this, either option requires a source-of-truth workstream before safe automation.
-
-These gaps do not automatically eliminate the options, but they materially affect sequencing. Option B should not be selected as the near-term target unless origin trust and source-of-truth ownership are resolved. Option A may still require a source-of-truth layer for safe URL category automation, but it preserves Palo Alto as an independent application-level enforcement point while the upstream control plane matures.
-
-
-## Recommended Automation Program Approach
-
-This should be treated as a phased ingress automation program, not a single vulnerability-scanner-to-firewall integration. The immediate operational pain is broader than scan-gated admission:
-
-- New backend GKE clusters require manual XNLB forwarding rule / public IP work.
-- New applications require cluster-specific CNAME / URL-category policy updates on the internet Palo Alto firewalls.
-- The timing of new cluster creation is not always evident to Network Security.
-- Vulnerability scan status is only one input into whether an application should be admitted to the public ingress path.
-- Several required control-plane capabilities span GTM / DDI, Imperva, Cequence, Palo Alto, GKE platform, AppSec scanning, and observability teams.
-
-The recommended approach is to separate the program into maturity phases.
-
-### Phase 0: Discovery and Ownership Alignment
-
-Goal: define the real systems of record, ownership boundaries, and capability gaps before building automation.
-
-Key outcomes:
-
-- Identify who owns app onboarding metadata.
-- Identify who owns cluster/origin/XNLB lifecycle.
-- Confirm whether clients can spoof or influence origin-selection headers.
-- Confirm whether scanner-only edge access is technically possible.
-- Confirm current Palo Alto policy/category behavior and whether URL categories are reliable app-level controls.
-- Define required audit fields for app exposure decisions.
-
-Deliverable: capability matrix and owner map.
-
-### Phase 1: Cluster Ingress Registration
-
-Goal: make new cluster ingress capacity explicit and reviewable.
-
-Instead of starting with per-app policy automation, first create a cluster registration workflow for internet-capable GKE clusters.
-
-Example cluster registration record:
-
-```yaml
-cluster_id: gke-prod-usw2-01
-environment: prod
-platform_owner: gke-platform-team
-origin_name: cluster-prod-usw2-01.ingress.example.net
-xnlb_forwarding_rule: fr-prod-usw2-01
-xnlb_vip: 203.0.113.10
-gke_backend_ilb: 10.10.20.15
-palo_nat_rule: nat-gke-prod-usw2-01
-palo_security_rule: allow-edge-to-gke-prod-usw2-01
-palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
-allowed_edge_sources:
-  - imperva_nat_pool_prod
-  - cequence_nat_pool_prod
-state: proposed | provisioned | active | deprecated | retired
-```
-
-This phase does not need to solve app admission yet. It creates visibility into which clusters are internet-capable and which Palo Alto / XNLB objects correspond to each cluster.
-
-### Phase 2: App-to-Cluster Admission Registry
-
-Goal: track application onboarding intent before changing firewall or edge policy.
-
-Example application registration record:
-
-```yaml
-app_fqdn: app.example.com
-owner: application-team
-environment: prod
-target_cluster_id: gke-prod-usw2-01
-scan_required: true
-scan_status: not_started | running | passed | failed | waived
-publication_state: requested | scanner_only | approved | active | revoked
-created_by: onboarding-api
-approved_by: appsec-or-netsec
-expires_at: null
-```
-
-This phase creates the missing source of truth. It can initially be lightweight, even if final automation is not ready.
-
-### Phase 3: Transitional Palo Alto Automation
-
-Goal: reduce manual Palo Alto work without removing the existing firewall-level app gate.
-
-Recommended near-term automation:
-
-```text
-app registration exists
-→ scan passes or waiver approved
-→ controller validates app-to-cluster mapping
-→ controller proposes or applies Palo Alto URL category update
-→ Panorama commit/push
-→ public-path validation
-```
-
-This maps to Option C implemented with Option A-style enforcement and is likely the safest transitional pattern while origin trust, scanner-only access, and onboarding source-of-truth maturity are still unresolved.
-
-### Phase 4: Edge-Controlled Admission Pilot
-
-Goal: prove whether Option B is viable for a limited scope.
-
-Pilot only after these capabilities are validated:
-
-- Cequence/Imperva can enforce scanner-only access per app.
-- Origin-selection metadata is trusted, overwritten, or validated.
-- App-to-cluster mapping is authoritative and auditable.
-- Public-path scanner validation is available.
-- Revocation works without manual firewall edits.
-
-If successful, Palo Alto can move toward cluster-scoped edge-to-origin rules for selected low-risk clusters/apps.
-
-### Phase 5: Broader Option B Adoption
-
-Goal: make GTM / Imperva / Cequence onboarding the primary app admission control point and remove routine per-app Palo Alto URL category work.
-
-This phase should only proceed after the edge-control pilot proves the model and SecOps telemetry can preserve app-level visibility outside Palo Alto URL categories.
-
-## Near-Term Recommendation
-
-Do not start by wiring vulnerability scanner pass/fail directly to public route activation. The safer near-term program is to implement Option C and use it to codify the current controls first:
-
-1. Build cluster ingress registration so new XNLB / Palo Alto / GKE ILB mappings are visible.
-2. Build app-to-cluster admission records so application onboarding has an owner, target cluster, scan state, and lifecycle state.
-3. Automate Palo Alto URL category updates as a transitional control, with human approval where needed.
-4. In parallel, run capability discovery for scanner-only edge access and trusted origin selection.
-5. Revisit Option B after the onboarding control plane and edge controls can safely replace firewall-level app allowlisting.
-
-This keeps the program grounded in the current pain while still leaving a path to the cleaner target architecture.
-
-## Recommendation
-
-Proceed toward **Option B** as the target pattern if the organization is willing to make GTM / Cequence onboarding the authoritative application admission control point.
-
-Under Option B:
-
-- Palo Alto enforces cluster-scoped edge-to-origin access.
-- GTM / Cequence / onboarding automation enforces application publication state.
-- Vulnerability scan success promotes the application from scanner-only access to normal public access.
-- Post-admission validation confirms that the real public chain works.
-
-Use **Option A** when independent Palo Alto app-level allowlisting is required or while the upstream onboarding controller is not yet mature enough to be the system of record for internet application admission.
-
-## Consequences
-
-### Positive
-
-- Establishes a clear decision boundary between scanning, routing, and firewall enforcement
-- Reduces manual firewall policy work for internet-facing GKE applications if Option B is adopted
-- Preserves a conservative fallback option with Palo Alto URL categories
-- Encourages source-of-truth-driven ingress onboarding instead of ad hoc firewall updates
-
-### Negative
-
-- Option B requires stronger governance around the GTM / Cequence onboarding control plane
-- Existing Palo Alto URL category controls may need to be retired carefully to avoid visibility or audit gaps
-- Scanner-only pre-admission access must be designed carefully to avoid becoming a permanent bypass
-- The public chain remains operationally complex even if firewall category management is simplified
-
-## Risks and Mitigations
-
-| Risk | Likelihood | Impact | Mitigation |
-|------|------------|--------|------------|
-| Upstream route activation becomes the only application admission gate without enough auditability | Medium | High | Require signed scan results, source-of-truth records, full audit logs, and reversible state transitions before removing Palo Alto URL categories. |
-| Scanner-only access becomes a permanent exception path | Medium | High | Time-bound scanner access, enforce scanner source IPs, and require automatic cleanup after pass/fail. |
-| Origin header or route-selection metadata is spoofed | Medium | High | Only trust metadata inserted by controlled edge/onboarding components; validate origin mapping server-side; restrict XNLB VIP access to approved edge NAT pools. |
-| Palo Alto loses useful app-level visibility | Medium | Medium | Integrate GTM / Imperva / Cequence logs with firewall logs and preserve app FQDN in centralized telemetry. |
-| Stale app records remain active after retirement | Medium | Medium | Require lifecycle state, owner metadata, expiration / review, and automated revocation. |
-| Public-path scan passes but backend mapping points to the wrong cluster | Low | High | Validate FQDN, Cequence origin, XNLB forwarding rule, Palo NAT, and GKE ILB mapping before promotion. |
-
-## Recommendation Summary
-
-| Option | Recommendation | Why |
-|--------|----------------|-----|
-| **Option A: Palo Alto URL category admission** | Conservative enforcement model | Maintains independent firewall app allowlisting but duplicates state and keeps onboarding operationally heavy. |
-| **Option B: GTM / Cequence admission with cluster-scoped Palo Alto rules** | Long-term target candidate | Simplifies firewall operations and places app admission in the onboarding / edge control plane, provided strong audit and rollback controls exist. |
-| **Option C: NetSec internet app repository** | Recommended near-term program | Codifies current NetSec-owned controls, creates an incremental source of truth, and enables safer PAN-OS automation without requiring immediate multi-team control-plane maturity. |
+Phase 1 should focus on codifying the current Palo Alto URL category workflow. Later phases can add scanner webhooks, remediation actions, expiration, revocation, and broader edge-control integration.
+
+## Why Not Start With Option B?
+
+Option B is cleaner on paper, but it depends on capabilities that are not currently proven.
+
+Known gaps:
+
+- **Origin selection is not trusted today.** Current understanding is that clients may be able to set `X-Forwarded-Origin` directly to an FQDN or IP.
+- **No official onboarding source of record is known today.** There is no clear authoritative system for `app → owner/env → cluster → origin → XNLB → policy/lifecycle`.
+- **Scanner-only staged access is not confirmed.** It is unknown whether Imperva/Cequence can make one app reachable only by scanner IPs before general availability.
+
+Until those are solved, Option B would move app admission upstream without enough control-plane maturity.
+
+## Assumptions to Validate
+
+These are the high-ticket items for stakeholder discussion.
+
+| Area | Question | Why It Matters |
+|------|----------|----------------|
+| **PAN-OS Terraform** | Can the provider safely manage URL categories, NAT/security policy, device groups, and commit/push? | Determines whether Option C can reduce firewall toil. |
+| **Existing Palo state** | Can current categories/rules be imported or reconciled without destructive drift? | Prevents Terraform adoption from breaking production policy. |
+| **XNLB ownership** | Does NetSec create XNLB forwarding rules, or only reference platform-created cluster records? | Defines repo scope and team ownership. |
+| **Cluster registration** | Who creates a cluster record when a new internet-capable GKE cluster is built? | Solves the current visibility gap. |
+| **Scan gating** | Can CI require scan pass, scan ID, waiver, or manual approval before app activation? | Adds scan status without making the scanner a firewall admin. |
+| **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
+| **Scanner path** | Can the scanner test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE? | A private/bypass scan does not validate the internet path. |
+| **Approvals** | Who can request, approve, merge, and apply production app exposure changes? | Prevents app teams from self-approving internet access. |
+| **Revocation** | Can removing/changing an app record revoke access cleanly? | Onboarding automation must also handle decommissioning. |
+| **Secrets/state** | Where do Panorama credentials and Terraform state live, and who can access them? | Avoids creating a new privileged automation risk. |
+
+## Phased Program
+
+| Phase | Goal | Output |
+|-------|------|--------|
+| **0. Discovery** | Confirm owners and capability gaps | Owner map + capability matrix |
+| **1. Cluster registration** | Make internet-capable clusters visible | `clusters/*.yaml` records |
+| **2. App registration** | Track app-to-cluster admission intent | `apps/*.yaml` records |
+| **3. PAN-OS automation** | Automate current Palo URL category process | Terraform-managed category membership |
+| **4. Scanner integration** | Add scan pass/waiver as a repo gate | CI/webhook/remediation workflow |
+| **5. Edge admission pilot** | Test Option B for limited scope | Scanner-only → active route promotion |
 
 ## Open Questions
 
-- Which system is the authoritative source of truth for app FQDN to cluster origin mapping?
-- Can Cequence enforce scanner-only pre-admission access and then promote to normal access after scan pass?
-- Are Imperva / Cequence NAT pools stable and fully known for Palo Alto source restrictions?
-- Can the onboarding API safely generate and preserve the required origin metadata without allowing spoofing?
-- What telemetry will replace Palo Alto URL-category visibility if Option B is selected?
-- What is the retirement / revocation process for decommissioned public applications?
-- Should the NetSec internet app repository provision XNLB forwarding rules, or only reference cluster records produced by the GKE/platform team?
-- Can existing Palo Alto URL categories and policies be safely imported into Terraform state?
-- Who approves production app admission PRs and who is allowed to trigger PAN-OS applies?
+- Can existing Palo Alto URL categories and rules be safely imported into Terraform state?
+- Should this repo provision XNLB forwarding rules or only reference platform-owned records?
+- Who owns cluster registration when new internet-capable GKE clusters are created?
+- Can Imperva/Cequence enforce scanner-only pre-admission access per app?
+- Can origin-selection headers be made non-client-controllable?
+- What telemetry replaces Palo URL-category visibility if Option B is ever adopted?
 
-## References
+## Recommendation Summary
 
-- Existing GCP egress ADR: `./adr-gcp-internet-egress-architecture.md`
+Start with **Option C**.
+
+It reduces immediate NetSec toil, creates the missing source-of-truth layer, and keeps the existing Palo Alto enforcement model intact while the broader organization figures out whether GTM/Cequence can eventually own app-level admission.

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -225,8 +225,8 @@ This option assumes the edge/onboarding control plane can become the authoritati
 | The scanner can test the real public hostname | Can the scanner target `https://app.example.com` through GTM, Imperva, Cequence, XNLB, Palo Alto, and GKE ILB? | A scan against a private/bypass path does not validate the production internet chain. |
 | Scanner-only access can be restricted per app | Can Imperva/Cequence allow only scanner public IPs for one app without opening other apps on the same cluster origin? | Prevents scanner pre-admission access from becoming broad cluster exposure. |
 | Cequence can enforce app-level admission reliably | Can Cequence distinguish app hostnames and promote/revoke a single app without impacting other apps on the same origin? | Option B removes Palo URL categories, so app-level admission must move upstream. |
-| Origin selection metadata is trusted and non-spoofable | Is the X-Forwarded-Origin/origin-selection value inserted or overwritten only by trusted systems? What happens if a client sends its own value? | If clients can influence origin selection, traffic could be routed to unintended clusters. |
-| The onboarding system is a real source of truth | Does an authoritative record exist for `app FQDN -> owner -> environment -> cluster -> origin -> XNLB forwarding rule -> lifecycle state`? | The scanner result only says the app passed; it does not know where the app is allowed to route. |
+| Origin selection metadata is trusted and non-spoofable | Is the X-Forwarded-Origin/origin-selection value inserted or overwritten only by trusted systems? What happens if a client sends its own value? | If clients can influence origin selection, traffic could be routed to unintended clusters. Current understanding: clients may already be able to set X-Forwarded-Origin to an FQDN or IP, so this assumption is not currently validated and may be false. |
+| The onboarding system is a real source of truth | Does an authoritative record exist for `app FQDN -> owner -> environment -> cluster -> origin -> XNLB forwarding rule -> lifecycle state`? | The scanner result only says the app passed; it does not know where the app is allowed to route. Current understanding: no official source of record exists today, so this is a major workstream for Option B. |
 | Palo Alto can be safely reduced to cluster-scoped policy | Are Imperva/Cequence NAT pools stable and complete, and are XNLB VIPs reachable only from those approved sources? | Palo becomes the edge-to-cluster boundary instead of per-app admission control. |
 | App identity remains visible outside Palo Alto URL categories | Can logs from GTM, Imperva, Cequence, Palo Alto, and GKE be correlated by FQDN/app ID? | Removing URL categories should not create an audit/forensics blind spot. |
 | Promotion and rollback are first-class state transitions | Can automation move `scanner_only -> active -> revoked` cleanly and quickly? | Internet exposure must be reversible without emergency manual edits. |
@@ -303,14 +303,24 @@ Before selecting either option, the stakeholder teams should validate the follow
 | Scanner can scan the public application FQDN through the real internet ingress chain | Application Security / Scanner Team | Required for final validation | Required for final admission |
 | Scanner results are signed/trustworthy and tied to a specific onboarding request | Application Security / Platform | Required | Required |
 | GTM / Imperva / Cequence can create scanner-only pre-admission access per app | Edge / WAF / Bot Teams | Helpful | Required |
-| Cequence origin selection is deterministic and protected from client spoofing | Cequence / Edge Team | Required to validate path | Required for admission control |
-| Source-of-truth mapping exists for app FQDN to cluster/origin/XNLB | Platform / DDI / Edge / NetSec | Required for correct category updates | Required for route promotion |
+| Cequence origin selection is deterministic and protected from client spoofing | Cequence / Edge Team | Required to validate path | Required for admission control; currently suspected false if clients can set X-Forwarded-Origin directly |
+| Source-of-truth mapping exists for app FQDN to cluster/origin/XNLB | Platform / DDI / Edge / NetSec | Required for correct category updates | Required for route promotion; currently no official source of record is known |
 | Palo Alto API automation can update URL categories and commit/push safely | Network Security | Required | Not required for app admission |
 | Palo Alto policy can be safely scoped to edge NAT pools and cluster XNLB VIPs | Network Security | Useful | Required |
 | Telemetry can correlate app FQDN across GTM, Imperva, Cequence, Palo Alto, and GKE | SecOps / Observability | Required | Required, especially if URL categories are removed |
 | Revocation/expiration can disable public exposure per app | Platform / Edge / NetSec | Required | Required |
 
 If the staged edge route, origin trust, scanner public-path testing, or onboarding source of truth cannot be validated, Option B should not be selected as the immediate target. In that case, Option A is the safer transitional automation pattern because Palo Alto remains an independent application-level enforcement point.
+
+
+## Current Known Gaps
+
+The following gaps are known or suspected as of this draft and should be treated as primary discussion points with stakeholder teams:
+
+- **Origin header trust is not established.** Current understanding is that clients can set `X-Forwarded-Origin` directly to an FQDN or IP. If true, origin selection cannot be treated as a trusted admission signal unless the edge chain overwrites, strips, signs, or otherwise validates this value before Cequence uses it.
+- **No official onboarding source of record is known.** There does not appear to be a single authoritative system that binds app FQDN, owner, environment, cluster, origin, XNLB forwarding rule, Palo Alto policy/category, scan state, and lifecycle state. Without this, either option requires a source-of-truth workstream before safe automation.
+
+These gaps do not automatically eliminate the options, but they materially affect sequencing. Option B should not be selected as the near-term target unless origin trust and source-of-truth ownership are resolved. Option A may still require a source-of-truth layer for safe URL category automation, but it preserves Palo Alto as an independent application-level enforcement point while the upstream control plane matures.
 
 ## Recommendation
 

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -87,17 +87,14 @@ state: requested | provisioned | active | deprecated | retired
 
 ### App admission record example
 
-Apps bind to an already-provisioned cluster ingress path. Phase 1 updates the cluster-specific Palo Alto URL category; scan status can start as metadata/manual evidence and later become detective/remediation automation.
+Apps bind to an already-provisioned cluster ingress path by referencing `target_cluster`. The cluster record determines the Palo Alto URL category and other firewall implementation details. App records should not repeat cluster-derived firewall fields. Scan status can start as metadata/manual evidence and later become detective/remediation automation.
 
 ```yaml
 fqdn: app.example.com
 owner: application-team
 environment: prod
 target_cluster: gke-prod-usw2-01
-palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
-admission:
-  state: requested | approved | active | revoked
-  approval: netsec-approved
+state: proposed | active | revoked
 scan:
   mode: detective_remediation
   status: not_started | passed | failed | waived
@@ -123,7 +120,7 @@ Platform builds GKE cluster + backend ILB
 ```text
 App onboarding request
 → PR adds/updates app record targeting an existing cluster record
-→ CI derives target Palo category from the cluster record and validates metadata, approval/scan/waiver state, and policy constraints
+→ CI derives target Palo category from the cluster record and validates metadata, scan/waiver state, and policy constraints
 → Terraform plan shows Palo Alto URL category membership change
 → NetSec review + approval
 → Terraform apply updates Palo Alto
@@ -159,7 +156,7 @@ These are the high-ticket items for stakeholder discussion.
 | **Scan gating** | Can CI require scan pass, scan ID, waiver, or manual approval before app activation? | Adds scan status without making the scanner a firewall admin. |
 | **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
 | **Scanner path** | The scanner likely must test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE. If no scanner-only pre-admission path exists, scanning cannot be a strict preventative gate before initial exposure. | In that case, scan integration should start as detective/remediation CI: detect failed scans after exposure, notify owners, open remediation PRs/issues, and optionally remove/revoke Palo category membership after policy-defined failure windows. |
-| **Approvals** | Who can request, approve, merge, and apply production app exposure changes? | Prevents app teams from self-approving internet access. |
+| **Approvals** | Who can request, review, merge, and apply production app exposure changes? | The app record is the proposed registration; approval should be represented by PR review/merge controls, not a vague `approval` field in the YAML. |
 | **Revocation** | Can removing/changing an app record revoke access cleanly? | Onboarding automation must also handle decommissioning. |
 | **Secrets/state** | Where do Panorama credentials and Terraform state live, and who can access them? | Avoids creating a new privileged automation risk. |
 

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -87,7 +87,7 @@ state: requested | provisioned | active | deprecated | retired
 
 ### App admission record example
 
-Apps bind to an already-provisioned cluster ingress path by referencing `target_cluster`. The cluster record determines the Palo Alto URL category and other firewall implementation details. App records should not repeat cluster-derived firewall fields. Scan status can start as metadata/manual evidence and later become detective/remediation automation.
+Apps bind to an already-provisioned cluster ingress path by referencing `target_cluster`. The cluster record determines the Palo Alto URL category and other firewall implementation details. App records should not repeat cluster-derived firewall fields, and requestors should not choose scanner behavior. Vulnerability scan status should be produced by CI/AppSec integration as an external check or status, not supplied as app intent.
 
 ```yaml
 fqdn: app.example.com
@@ -95,10 +95,6 @@ owner: application-team
 environment: prod
 target_cluster: gke-prod-usw2-01
 state: proposed | active | revoked
-scan:
-  mode: detective_remediation
-  status: not_started | passed | failed | waived
-  scan_id: null
 ```
 
 ### Flow
@@ -120,7 +116,7 @@ Platform builds GKE cluster + backend ILB
 ```text
 App onboarding request
 → PR adds/updates app record targeting an existing cluster record
-→ CI derives target Palo category from the cluster record and validates metadata, scan/waiver state, and policy constraints
+→ CI derives target Palo category from the cluster record and validates metadata, required checks/waivers, and policy constraints
 → Terraform plan shows Palo Alto URL category membership change
 → NetSec review + approval
 → Terraform apply updates Palo Alto
@@ -153,7 +149,7 @@ These are the high-ticket items for stakeholder discussion.
 | **Existing Palo state** | Can current categories/rules be imported or reconciled without destructive drift? | Prevents Terraform adoption from breaking production policy. |
 | **XNLB ownership** | NetSec creates and owns XNLB forwarding rules, and Option C may provision those GCP resources from the same repo that stores app/cluster intent. Platform should trigger the cluster registration workflow after building a new internet-capable GKE cluster. | Defines repo scope and team handoff. |
 | **Cluster registration** | Platform initiates the cluster record after building a new internet-capable GKE cluster; NetSec repo provisions or records the XNLB forwarding rule/public IP and Palo mapping. | Solves the current visibility gap and gives the requestor the origin IP/name required for GTM onboarding. |
-| **Scan gating** | Can CI require scan pass, scan ID, waiver, or manual approval before app activation? | Adds scan status without making the scanner a firewall admin. |
+| **Scan integration** | Can CI/AppSec publish scan results or waivers as checks/status outside the requester-supplied app YAML? | Adds scan visibility without asking requestors to declare scanner mode/status themselves. |
 | **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
 | **Scanner path** | The scanner likely must test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE. If no scanner-only pre-admission path exists, scanning cannot be a strict preventative gate before initial exposure. | In that case, scan integration should start as detective/remediation CI: detect failed scans after exposure, notify owners, open remediation PRs/issues, and optionally remove/revoke Palo category membership after policy-defined failure windows. |
 | **Approvals** | Who can request, review, merge, and apply production app exposure changes? | The app record is the proposed registration; approval should be represented by PR review/merge controls, not a vague `approval` field in the YAML. |
@@ -170,7 +166,7 @@ Near-term scan integration should be treated as **detective/remediation CI**:
 app access is approved through NetSec repo
 → public path becomes reachable
 → scanner tests real FQDN through the production ingress chain
-→ scan result updates app record / PR status / issue
+→ scan result updates PR status / external check / issue
 → failed scan triggers remediation workflow or access revocation based on policy
 ```
 
@@ -200,7 +196,7 @@ Important boundary: requestors can provide the backend GKE ILB because that is t
 | **1. Cluster ingress bootstrap** | Create/register internet-capable cluster ingress path | `clusters/*.yaml`, backend ILB input, XNLB forwarding rule/public IP output, Palo NAT/security/category mapping, GTM onboarding output |
 | **2. App registration** | Track app-to-cluster admission intent | `apps/*.yaml` records |
 | **3. PAN-OS automation** | Automate current Palo URL category process | Terraform-managed category membership |
-| **4. Scanner integration** | Add scan pass/waiver as a repo gate | CI/webhook/remediation workflow |
+| **4. Scanner integration** | Add scan results/waivers as external repo checks | CI/webhook/remediation workflow |
 | **5. Edge admission pilot** | Test Option B for limited scope | Scanner-only → active route promotion |
 
 ## Open Questions
@@ -209,7 +205,7 @@ Important boundary: requestors can provide the backend GKE ILB because that is t
 - What exact GCP permissions/project boundaries are required for the NetSec repo to provision XNLB forwarding rules and reserve public IPs?
 - What output format should the NetSec workflow provide to the requestor for the follow-on GTM onboarding API payload?
 - What exact handoff does Platform use to submit the post-build cluster intent record?
-- If no scanner-only pre-admission path exists, should scan integration be detective/remediation first rather than preventative?
+- If no scanner-only pre-admission path exists, should scan integration be detective/remediation first rather than preventative, using external CI/AppSec checks instead of requester-supplied fields?
 - What SLA/action should occur when a newly exposed app fails scan: notify only, block future changes, remove Palo URL category membership, or require manual exception?
 - Can Imperva/Cequence enforce scanner-only pre-admission access per app in the future?
 - Can origin-selection headers be made non-client-controllable?

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -118,6 +118,21 @@ scanner_sources:
 state: requested | scanned_pass | approved | active | expired | revoked
 ```
 
+
+### Assumptions to Validate
+
+This option assumes the organization can safely automate Palo Alto URL category updates without making the vulnerability scanner a direct firewall policy authority.
+
+| Assumption | Validation Question | Why It Matters |
+|------------|---------------------|----------------|
+| A Network Security-owned controller can update Panorama objects safely | Is there an approved API path for adding/removing FQDNs from custom URL categories and committing/pushing changes? | Without this, Option A remains manual or requires brittle automation around firewall operations. |
+| The scanner emits trustworthy pass/fail events | Are scan result webhooks signed, tied to a scan ID, and bound to the exact application FQDN/onboarding request? | Scan success becomes a condition for internet exposure; replayed or ambiguous scan events cannot be accepted. |
+| A source of truth can map app FQDN to the correct firewall object | Can automation resolve `app FQDN -> cluster/origin -> XNLB forwarding rule -> Palo URL category` deterministically? | Prevents the controller from adding the right app to the wrong cluster/category path. |
+| Palo Alto URL category matching is the intended app-level control | Does the policy actually evaluate the hostname/category in the expected traffic leg, and does TLS/SNI/HTTP visibility support that match? | If the firewall cannot reliably evaluate the app identity, URL categories provide false confidence. |
+| Panorama commit/push latency is acceptable for onboarding | How long does an object update and commit/push take, and what happens on partial failure? | Each app promotion depends on firewall control-plane timing and failure handling. |
+| URL category lifecycle can be managed | Can automation remove entries on app retirement, failed scans, expiration, or revocation? | Otherwise categories become stale allowlists. |
+| Post-change validation can prove the public path | Can a synthetic probe confirm `FQDN -> Imperva -> Cequence -> XNLB -> Palo -> GKE ILB` after the category update? | Prevents policy success from being mistaken for end-to-end application reachability. |
+
 ### Benefits
 
 - Preserves independent firewall-level app allowlisting
@@ -199,6 +214,23 @@ Approved public users
 
 The vulnerability scanner should generally test the same public ingress chain that users will hit. A separate private scanner path can validate application behavior earlier in CI/CD, but it does not prove the internet ingress chain is correctly configured.
 
+
+### Assumptions to Validate
+
+This option assumes the edge/onboarding control plane can become the authoritative application admission point, while Palo Alto policy is simplified to cluster-scoped edge-to-origin enforcement.
+
+| Assumption | Validation Question | Why It Matters |
+|------------|---------------------|----------------|
+| GTM / Imperva / Cequence can support a staged application route | Can an app hostname exist in `scanner_only` state before being promoted to normal public access? | Without staged route state, scan-before-general-access is difficult or requires temporary firewall exceptions. |
+| The scanner can test the real public hostname | Can the scanner target `https://app.example.com` through GTM, Imperva, Cequence, XNLB, Palo Alto, and GKE ILB? | A scan against a private/bypass path does not validate the production internet chain. |
+| Scanner-only access can be restricted per app | Can Imperva/Cequence allow only scanner public IPs for one app without opening other apps on the same cluster origin? | Prevents scanner pre-admission access from becoming broad cluster exposure. |
+| Cequence can enforce app-level admission reliably | Can Cequence distinguish app hostnames and promote/revoke a single app without impacting other apps on the same origin? | Option B removes Palo URL categories, so app-level admission must move upstream. |
+| Origin selection metadata is trusted and non-spoofable | Is the X-Forwarded-Origin/origin-selection value inserted or overwritten only by trusted systems? What happens if a client sends its own value? | If clients can influence origin selection, traffic could be routed to unintended clusters. |
+| The onboarding system is a real source of truth | Does an authoritative record exist for `app FQDN -> owner -> environment -> cluster -> origin -> XNLB forwarding rule -> lifecycle state`? | The scanner result only says the app passed; it does not know where the app is allowed to route. |
+| Palo Alto can be safely reduced to cluster-scoped policy | Are Imperva/Cequence NAT pools stable and complete, and are XNLB VIPs reachable only from those approved sources? | Palo becomes the edge-to-cluster boundary instead of per-app admission control. |
+| App identity remains visible outside Palo Alto URL categories | Can logs from GTM, Imperva, Cequence, Palo Alto, and GKE be correlated by FQDN/app ID? | Removing URL categories should not create an audit/forensics blind spot. |
+| Promotion and rollback are first-class state transitions | Can automation move `scanner_only -> active -> revoked` cleanly and quickly? | Internet exposure must be reversible without emergency manual edits. |
+
 ### Benefits
 
 - Removes duplicate per-app allowlist state from Palo Alto
@@ -260,6 +292,25 @@ Scanner network
 ```
 
 This validates the application but does not validate the final internet ingress architecture. It should not be the only gate for public exposure.
+
+
+## Capability Discovery Required Before Selection
+
+Before selecting either option, the stakeholder teams should validate the following high-ticket capabilities. These are gating assumptions, not implementation details.
+
+| Capability | Owner to Confirm | Option A Dependency | Option B Dependency |
+|------------|------------------|---------------------|---------------------|
+| Scanner can scan the public application FQDN through the real internet ingress chain | Application Security / Scanner Team | Required for final validation | Required for final admission |
+| Scanner results are signed/trustworthy and tied to a specific onboarding request | Application Security / Platform | Required | Required |
+| GTM / Imperva / Cequence can create scanner-only pre-admission access per app | Edge / WAF / Bot Teams | Helpful | Required |
+| Cequence origin selection is deterministic and protected from client spoofing | Cequence / Edge Team | Required to validate path | Required for admission control |
+| Source-of-truth mapping exists for app FQDN to cluster/origin/XNLB | Platform / DDI / Edge / NetSec | Required for correct category updates | Required for route promotion |
+| Palo Alto API automation can update URL categories and commit/push safely | Network Security | Required | Not required for app admission |
+| Palo Alto policy can be safely scoped to edge NAT pools and cluster XNLB VIPs | Network Security | Useful | Required |
+| Telemetry can correlate app FQDN across GTM, Imperva, Cequence, Palo Alto, and GKE | SecOps / Observability | Required | Required, especially if URL categories are removed |
+| Revocation/expiration can disable public exposure per app | Platform / Edge / NetSec | Required | Required |
+
+If the staged edge route, origin trust, scanner public-path testing, or onboarding source of truth cannot be validated, Option B should not be selected as the immediate target. In that case, Option A is the safer transitional automation pattern because Palo Alto remains an independent application-level enforcement point.
 
 ## Recommendation
 

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -322,6 +322,131 @@ The following gaps are known or suspected as of this draft and should be treated
 
 These gaps do not automatically eliminate the options, but they materially affect sequencing. Option B should not be selected as the near-term target unless origin trust and source-of-truth ownership are resolved. Option A may still require a source-of-truth layer for safe URL category automation, but it preserves Palo Alto as an independent application-level enforcement point while the upstream control plane matures.
 
+
+## Recommended Automation Program Approach
+
+This should be treated as a phased ingress automation program, not a single vulnerability-scanner-to-firewall integration. The immediate operational pain is broader than scan-gated admission:
+
+- New backend GKE clusters require manual XNLB forwarding rule / public IP work.
+- New applications require cluster-specific CNAME / URL-category policy updates on the internet Palo Alto firewalls.
+- The timing of new cluster creation is not always evident to Network Security.
+- Vulnerability scan status is only one input into whether an application should be admitted to the public ingress path.
+- Several required control-plane capabilities span GTM / DDI, Imperva, Cequence, Palo Alto, GKE platform, AppSec scanning, and observability teams.
+
+The recommended approach is to separate the program into maturity phases.
+
+### Phase 0: Discovery and Ownership Alignment
+
+Goal: define the real systems of record, ownership boundaries, and capability gaps before building automation.
+
+Key outcomes:
+
+- Identify who owns app onboarding metadata.
+- Identify who owns cluster/origin/XNLB lifecycle.
+- Confirm whether clients can spoof or influence origin-selection headers.
+- Confirm whether scanner-only edge access is technically possible.
+- Confirm current Palo Alto policy/category behavior and whether URL categories are reliable app-level controls.
+- Define required audit fields for app exposure decisions.
+
+Deliverable: capability matrix and owner map.
+
+### Phase 1: Cluster Ingress Registration
+
+Goal: make new cluster ingress capacity explicit and reviewable.
+
+Instead of starting with per-app policy automation, first create a cluster registration workflow for internet-capable GKE clusters.
+
+Example cluster registration record:
+
+```yaml
+cluster_id: gke-prod-usw2-01
+environment: prod
+platform_owner: gke-platform-team
+origin_name: cluster-prod-usw2-01.ingress.example.net
+xnlb_forwarding_rule: fr-prod-usw2-01
+xnlb_vip: 203.0.113.10
+gke_backend_ilb: 10.10.20.15
+palo_nat_rule: nat-gke-prod-usw2-01
+palo_security_rule: allow-edge-to-gke-prod-usw2-01
+palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
+allowed_edge_sources:
+  - imperva_nat_pool_prod
+  - cequence_nat_pool_prod
+state: proposed | provisioned | active | deprecated | retired
+```
+
+This phase does not need to solve app admission yet. It creates visibility into which clusters are internet-capable and which Palo Alto / XNLB objects correspond to each cluster.
+
+### Phase 2: App-to-Cluster Admission Registry
+
+Goal: track application onboarding intent before changing firewall or edge policy.
+
+Example application registration record:
+
+```yaml
+app_fqdn: app.example.com
+owner: application-team
+environment: prod
+target_cluster_id: gke-prod-usw2-01
+scan_required: true
+scan_status: not_started | running | passed | failed | waived
+publication_state: requested | scanner_only | approved | active | revoked
+created_by: onboarding-api
+approved_by: appsec-or-netsec
+expires_at: null
+```
+
+This phase creates the missing source of truth. It can initially be lightweight, even if final automation is not ready.
+
+### Phase 3: Transitional Palo Alto Automation
+
+Goal: reduce manual Palo Alto work without removing the existing firewall-level app gate.
+
+Recommended near-term automation:
+
+```text
+app registration exists
+→ scan passes or waiver approved
+→ controller validates app-to-cluster mapping
+→ controller proposes or applies Palo Alto URL category update
+→ Panorama commit/push
+→ public-path validation
+```
+
+This maps to Option A and is likely the safest transitional pattern while origin trust, scanner-only access, and onboarding source-of-truth maturity are still unresolved.
+
+### Phase 4: Edge-Controlled Admission Pilot
+
+Goal: prove whether Option B is viable for a limited scope.
+
+Pilot only after these capabilities are validated:
+
+- Cequence/Imperva can enforce scanner-only access per app.
+- Origin-selection metadata is trusted, overwritten, or validated.
+- App-to-cluster mapping is authoritative and auditable.
+- Public-path scanner validation is available.
+- Revocation works without manual firewall edits.
+
+If successful, Palo Alto can move toward cluster-scoped edge-to-origin rules for selected low-risk clusters/apps.
+
+### Phase 5: Broader Option B Adoption
+
+Goal: make GTM / Imperva / Cequence onboarding the primary app admission control point and remove routine per-app Palo Alto URL category work.
+
+This phase should only proceed after the edge-control pilot proves the model and SecOps telemetry can preserve app-level visibility outside Palo Alto URL categories.
+
+## Near-Term Recommendation
+
+Do not start by wiring vulnerability scanner pass/fail directly to public route activation. The safer near-term program is:
+
+1. Build cluster ingress registration so new XNLB / Palo Alto / GKE ILB mappings are visible.
+2. Build app-to-cluster admission records so application onboarding has an owner, target cluster, scan state, and lifecycle state.
+3. Automate Palo Alto URL category updates as a transitional control, with human approval where needed.
+4. In parallel, run capability discovery for scanner-only edge access and trusted origin selection.
+5. Revisit Option B after the onboarding control plane and edge controls can safely replace firewall-level app allowlisting.
+
+This keeps the program grounded in the current pain while still leaving a path to the cleaner target architecture.
+
 ## Recommendation
 
 Proceed toward **Option B** as the target pattern if the organization is willing to make GTM / Cequence onboarding the authoritative application admission control point.

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -50,10 +50,13 @@ We will document and evaluate two viable patterns:
 
 1. **Option A: Retain Palo Alto custom URL categories as the application-level enforcement point**
 2. **Option B: Move application admission to the GTM / Cequence onboarding control plane and remove per-app Palo Alto URL category requirements**
+3. **Option C: Create a Network Security-owned internet application repository as the transitional control plane**
 
-The recommended direction is **Option B**, provided the GTM / Cequence onboarding control plane is made authoritative, auditable, reversible, and protected by clear guardrails.
+The recommended near-term direction is **Option C** because it codifies the controls Network Security owns today while creating the missing source-of-truth layer needed for either longer-term option.
 
-Option A remains a conservative fallback when Network Security requires independent firewall-level application allowlisting or when upstream admission controls are not yet mature enough to replace the Palo Alto URL-category gate.
+Option B remains the cleaner long-term target if the GTM / Cequence onboarding control plane becomes authoritative, auditable, reversible, and protected by clear guardrails.
+
+Option A remains a conservative implementation model when Network Security requires independent firewall-level application allowlisting or when upstream admission controls are not yet mature enough to replace the Palo Alto URL-category gate.
 
 ## Option A: Palo Alto URL Category as the Application Admission Gate
 
@@ -259,6 +262,142 @@ This option assumes the edge/onboarding control plane can become the authoritati
 - The onboarding controller must support revocation, expiration, and full audit history.
 - Post-admission synthetic validation must test the public path through GTM, Imperva, Cequence, XNLB, Palo Alto, and GKE ILB.
 
+
+## Option C: Network Security Internet Application Repository
+
+### Description
+
+In this model, Network Security creates a dedicated repository that acts as the near-term control plane for internet-facing GKE application admission and firewall-side implementation.
+
+The repository codifies the cluster and application records that are currently implicit or spread across teams. It can use Terraform and the PAN-OS provider to manage the firewall-side controls that Network Security owns today, while optionally referencing or provisioning related cloud-side objects when ownership is clarified.
+
+Example repository structure:
+
+```text
+netsec-internet-apps/
+├── clusters/
+│   ├── gke-prod-usw2-01.yaml
+│   └── gke-prod-use1-01.yaml
+├── apps/
+│   ├── app.example.com.yaml
+│   └── payments.example.com.yaml
+├── terraform/
+│   ├── panos-url-categories/
+│   ├── panos-security-policy/
+│   └── panos-nat-policy/
+└── .github/workflows/
+    ├── validate-app.yml
+    ├── plan-panos.yml
+    └── apply-panos.yml
+```
+
+Example cluster record:
+
+```yaml
+cluster_id: gke-prod-usw2-01
+environment: prod
+origin_name: cluster-prod-usw2-01.ingress.example.net
+xnlb_forwarding_rule: fr-gke-prod-usw2-01
+xnlb_vip: 203.0.113.10
+gke_backend_ilb: 10.10.20.15
+palo_device_group: dg-internet-prod
+palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
+allowed_edge_sources:
+  - imperva_prod_nat
+  - cequence_prod_nat
+state: active
+```
+
+Example application record:
+
+```yaml
+fqdn: app.example.com
+owner: application-team
+environment: prod
+target_cluster: gke-prod-usw2-01
+scan_status: passed
+scan_id: scan-12345
+state: active
+expires_at: null
+```
+
+### Traffic and Control Flow
+
+The runtime traffic path is the same as the current architecture:
+
+```text
+User or scanner
+→ public app hostname
+→ GTM / Imperva
+→ Cequence
+→ XNLB forwarding rule
+→ Palo Alto policy / NAT
+→ GKE ILB
+→ application
+```
+
+The control flow changes from manual requests to pull requests:
+
+```text
+App onboarding request
+→ PR adds or updates apps/app.example.com.yaml
+→ CI validates target cluster, required metadata, scan state, naming, and policy constraints
+→ Terraform plan shows Palo Alto URL category / policy / NAT changes
+→ approval and merge
+→ Terraform apply updates PAN-OS objects
+→ post-change validation confirms public path
+```
+
+Phase 1 should focus on codifying the current Palo Alto URL category process. Later phases can add scanner webhooks, remediation actions, expiration, revocation, and broader edge-control integration.
+
+### Assumptions to Validate
+
+This option assumes Network Security can own a repository-backed interface for the firewall-side and admission-record portions of internet app onboarding, even if other teams continue owning GTM, DDI, Imperva, Cequence, and GKE platform primitives.
+
+| Assumption | Validation Question | Why It Matters |
+|------------|---------------------|----------------|
+| Network Security can own the repo and review process | Is NetSec allowed to be the code owner for app-to-cluster firewall admission records and PAN-OS changes? | Without clear ownership, the repo becomes another unofficial spreadsheet with YAML cosplay. |
+| PAN-OS provider can manage required objects safely | Can Terraform manage custom URL categories, security rules, NAT rules, device groups, and commit/push behavior for the target Panorama/Palo Alto environment? | The repo is only useful if it can reliably implement the firewall-side changes. |
+| Existing Palo Alto state can be imported or reconciled | Can current URL categories, NAT rules, and security policies be imported into Terraform state or represented without destructive drift? | Prevents the first apply from becoming a change-management jump scare. |
+| XNLB forwarding rule ownership is clear | Does NetSec create XNLB VIPs/forwarding rules, or does the repo only reference cluster records created by the GKE/platform team? | Determines whether the repository provisions cloud-side ingress objects or only validates references. |
+| Cluster registration data can be supplied reliably | Who creates the cluster record when a new internet-capable GKE cluster is created? | Solves the current problem where new XNLB/cluster ingress capacity is not evident to NetSec. |
+| App records can require scan/approval metadata | Can CI enforce scan status, scan ID, waiver, owner, environment, and target cluster before allowing a merge? | Allows vulnerability scanning to become a policy gate without requiring direct scanner-to-firewall writes. |
+| Scanner integration can start asynchronous | Can the first version accept scan metadata manually or by PR comment/status, then later integrate webhooks? | Avoids blocking Phase 1 on a full multi-team scanner integration. |
+| Apply permissions and approvals are acceptable | Who can merge, who can apply, and is there a separation between requesters, approvers, and automation credentials? | Prevents app teams from self-approving internet exposure. |
+| Rollback and revocation can be represented as code | Can removing or changing an app record remove the CNAME/category entry and trigger validation? | The repo must handle decommissioning, not only onboarding. |
+| Secrets and provider credentials can be managed securely | Where will Panorama credentials, API keys, and GitHub Actions secrets live, and who can access them? | The automation should not create a new privileged secret sprawl problem. |
+| Change windows and commit timing are compatible with GitOps | Are Panorama commits/pushes allowed from CI, and do they need scheduled windows or manual gates? | Determines whether this can be fully automated or must remain plan-and-approve. |
+| Multi-team dependencies can be represented but not owned | Can the repo validate external prerequisites without pretending to own GTM, DDI, Imperva, Cequence, or scanner systems? | Keeps Phase 1 scoped to NetSec-owned controls instead of turning into a 13-team platform rewrite. |
+
+### Benefits
+
+- Creates the missing source-of-truth layer incrementally
+- Gives Network Security an auditable, reviewable, PR-based workflow for current manual firewall work
+- Reduces immediate toil around Palo Alto URL category membership
+- Supports naming conventions, validation, ownership metadata, scan metadata, and lifecycle state
+- Does not require GTM / Cequence to become a mature admission controller on day one
+- Provides a migration bridge toward Option B if edge-control capabilities mature later
+
+### Drawbacks
+
+- Still relies on Palo Alto URL categories during the transitional phase
+- Adds a new repository and GitOps workflow to operate
+- Requires Terraform state ownership and careful import/reconciliation of existing PAN-OS objects
+- Does not by itself solve GTM, DDI, Imperva, Cequence, or scanner ownership gaps
+- Could become the long-term source of truth by accident if a broader platform owner never emerges
+
+### Guardrails
+
+- Treat the repository as the source of truth for NetSec-owned admission records and firewall-side implementation only.
+- Require CODEOWNERS review from Network Security for production changes.
+- Require app owner, environment, target cluster, scan status or waiver, and lifecycle state on every app record.
+- Run CI validation before plan/apply.
+- Use plan review before production apply, at least during initial rollout.
+- Import or reconcile existing PAN-OS objects before enabling writes.
+- Do not allow app teams to bypass approval by editing app records directly.
+- Log every apply with PR number, approver, commit SHA, Terraform plan, and Panorama commit ID.
+- Keep GTM/DDI/Imperva/Cequence ownership explicit; do not silently make the NetSec repo responsible for systems it cannot enforce.
+
 ## Scanner Path Considerations
 
 The scanner path must be explicit because it changes what the scan result proves.
@@ -413,7 +552,7 @@ app registration exists
 → public-path validation
 ```
 
-This maps to Option A and is likely the safest transitional pattern while origin trust, scanner-only access, and onboarding source-of-truth maturity are still unresolved.
+This maps to Option C implemented with Option A-style enforcement and is likely the safest transitional pattern while origin trust, scanner-only access, and onboarding source-of-truth maturity are still unresolved.
 
 ### Phase 4: Edge-Controlled Admission Pilot
 
@@ -437,7 +576,7 @@ This phase should only proceed after the edge-control pilot proves the model and
 
 ## Near-Term Recommendation
 
-Do not start by wiring vulnerability scanner pass/fail directly to public route activation. The safer near-term program is:
+Do not start by wiring vulnerability scanner pass/fail directly to public route activation. The safer near-term program is to implement Option C and use it to codify the current controls first:
 
 1. Build cluster ingress registration so new XNLB / Palo Alto / GKE ILB mappings are visible.
 2. Build app-to-cluster admission records so application onboarding has an owner, target cluster, scan state, and lifecycle state.
@@ -491,8 +630,9 @@ Use **Option A** when independent Palo Alto app-level allowlisting is required o
 
 | Option | Recommendation | Why |
 |--------|----------------|-----|
-| **Option A: Palo Alto URL category admission** | Conservative fallback | Maintains independent firewall app allowlisting but duplicates state and keeps onboarding operationally heavy. |
-| **Option B: GTM / Cequence admission with cluster-scoped Palo Alto rules** | Preferred target | Simplifies firewall operations and places app admission in the onboarding / edge control plane, provided strong audit and rollback controls exist. |
+| **Option A: Palo Alto URL category admission** | Conservative enforcement model | Maintains independent firewall app allowlisting but duplicates state and keeps onboarding operationally heavy. |
+| **Option B: GTM / Cequence admission with cluster-scoped Palo Alto rules** | Long-term target candidate | Simplifies firewall operations and places app admission in the onboarding / edge control plane, provided strong audit and rollback controls exist. |
+| **Option C: NetSec internet app repository** | Recommended near-term program | Codifies current NetSec-owned controls, creates an incremental source of truth, and enables safer PAN-OS automation without requiring immediate multi-team control-plane maturity. |
 
 ## Open Questions
 
@@ -502,6 +642,9 @@ Use **Option A** when independent Palo Alto app-level allowlisting is required o
 - Can the onboarding API safely generate and preserve the required origin metadata without allowing spoofing?
 - What telemetry will replace Palo Alto URL-category visibility if Option B is selected?
 - What is the retirement / revocation process for decommissioned public applications?
+- Should the NetSec internet app repository provision XNLB forwarding rules, or only reference cluster records produced by the GKE/platform team?
+- Can existing Palo Alto URL categories and policies be safely imported into Terraform state?
+- Who approves production app admission PRs and who is allowed to trigger PAN-OS applies?
 
 ## References
 

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -108,6 +108,7 @@ Known gaps:
 - **Origin selection is not trusted today.** Current understanding is that clients may be able to set `X-Forwarded-Origin` directly to an FQDN or IP.
 - **No official onboarding source of record is known today.** There is no clear authoritative system for `app → owner/env → cluster → origin → XNLB → policy/lifecycle`.
 - **Scanner-only staged access is not confirmed.** It is unknown whether Imperva/Cequence can make one app reachable only by scanner IPs before general availability.
+- **There is a scanner bootstrap problem.** A scan cannot be a prerequisite for opening the same access path if the scanner has no pre-admission path to reach the application. The design must define how scanner traffic is allowed before general access, such as scanner-only edge policy, temporary Palo category membership, a preview/staging hostname, or a manual break-glass approval.
 
 Until those are solved, Option B would move app admission upstream without enough control-plane maturity.
 
@@ -123,7 +124,7 @@ These are the high-ticket items for stakeholder discussion.
 | **Cluster registration** | Who creates a cluster record when a new internet-capable GKE cluster is built? | Solves the current visibility gap. |
 | **Scan gating** | Can CI require scan pass, scan ID, waiver, or manual approval before app activation? | Adds scan status without making the scanner a firewall admin. |
 | **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
-| **Scanner path** | Can the scanner test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE? | A private/bypass scan does not validate the internet path. |
+| **Scanner path** | How does the scanner reach the app before general access is opened? Can it test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE using scanner-only access? | A scan cannot be the prerequisite for opening a path the scanner cannot yet use; a private/bypass scan does not validate the internet path. |
 | **Approvals** | Who can request, approve, merge, and apply production app exposure changes? | Prevents app teams from self-approving internet access. |
 | **Revocation** | Can removing/changing an app record revoke access cleanly? | Onboarding automation must also handle decommissioning. |
 | **Secrets/state** | Where do Panorama credentials and Terraform state live, and who can access them? | Avoids creating a new privileged automation risk. |
@@ -144,6 +145,7 @@ These are the high-ticket items for stakeholder discussion.
 - Can existing Palo Alto URL categories and rules be safely imported into Terraform state?
 - Should this repo provision XNLB forwarding rules or only reference platform-owned records?
 - Who owns cluster registration when new internet-capable GKE clusters are created?
+- How does the scanner get pre-admission access without granting general public access?
 - Can Imperva/Cequence enforce scanner-only pre-admission access per app?
 - Can origin-selection headers be made non-client-controllable?
 - What telemetry replaces Palo URL-category visibility if Option B is ever adopted?

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -120,8 +120,8 @@ These are the high-ticket items for stakeholder discussion.
 |------|----------|----------------|
 | **PAN-OS Terraform** | Can the provider safely manage URL categories, NAT/security policy, device groups, and commit/push? | Determines whether Option C can reduce firewall toil. |
 | **Existing Palo state** | Can current categories/rules be imported or reconciled without destructive drift? | Prevents Terraform adoption from breaking production policy. |
-| **XNLB ownership** | NetSec creates and owns XNLB forwarding rules. Platform should provide/trigger the cluster registration record after building a new internet-capable GKE cluster. | Defines repo scope and team handoff. |
-| **Cluster registration** | Who creates a cluster record when a new internet-capable GKE cluster is built? | Solves the current visibility gap. |
+| **XNLB ownership** | NetSec creates and owns XNLB forwarding rules, and Option C may provision those GCP resources from the same repo that stores app/cluster intent. Platform should trigger the cluster registration workflow after building a new internet-capable GKE cluster. | Defines repo scope and team handoff. |
+| **Cluster registration** | Platform initiates the cluster record after building a new internet-capable GKE cluster; NetSec repo provisions or records the XNLB forwarding rule/public IP and Palo mapping. | Solves the current visibility gap and gives the requestor the origin IP/name required for GTM onboarding. |
 | **Scan gating** | Can CI require scan pass, scan ID, waiver, or manual approval before app activation? | Adds scan status without making the scanner a firewall admin. |
 | **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
 | **Scanner path** | The scanner likely must test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE. If no scanner-only pre-admission path exists, scanning cannot be a strict preventative gate before initial exposure. | In that case, scan integration should start as detective/remediation CI: detect failed scans after exposure, notify owners, open remediation PRs/issues, and optionally remove/revoke Palo category membership after policy-defined failure windows. |
@@ -145,12 +145,28 @@ app access is approved through NetSec repo
 
 This avoids pretending scan pass can be required before the scanner has any route to the application. Preventative scan gating can be revisited later if Imperva/Cequence or another edge layer can provide scanner-only pre-admission access.
 
+## Cluster Onboarding Flow
+
+For new internet-capable GKE clusters, the repository can own the cluster ingress bootstrap instead of only referencing already-created objects.
+
+```text
+1. Platform builds GKE cluster and backend GKE ILB.
+2. Platform opens/merges a cluster intent record with backend ILB details.
+3. NetSec repo provisions or records the XNLB forwarding rule and reserved public IP.
+4. NetSec repo provisions/updates Palo Alto NAT, security policy, and cluster URL category.
+5. Workflow outputs the cluster origin information required for GTM onboarding.
+6. Requestor submits GTM onboarding API payload using the NetSec-provided origin/IP details.
+7. App records can then add CNAME/FQDN membership for that cluster path.
+```
+
+Important boundary: requestors can provide the backend GKE ILB because that is their/platform-owned target, but they should not choose the public XNLB IP directly. The XNLB public IP/forwarding rule should be allocated or returned by the NetSec workflow so the ingress path remains controlled and auditable.
+
 ## Phased Program
 
 | Phase | Goal | Output |
 |-------|------|--------|
 | **0. Discovery** | Confirm owners and capability gaps | Owner map + capability matrix |
-| **1. Cluster registration** | Make internet-capable clusters visible | `clusters/*.yaml` records |
+| **1. Cluster ingress bootstrap** | Create/register internet-capable cluster ingress path | `clusters/*.yaml`, XNLB forwarding rule/public IP, Palo NAT/security/category mapping, GTM origin output |
 | **2. App registration** | Track app-to-cluster admission intent | `apps/*.yaml` records |
 | **3. PAN-OS automation** | Automate current Palo URL category process | Terraform-managed category membership |
 | **4. Scanner integration** | Add scan pass/waiver as a repo gate | CI/webhook/remediation workflow |
@@ -159,7 +175,8 @@ This avoids pretending scan pass can be required before the scanner has any rout
 ## Open Questions
 
 - Can existing Palo Alto URL categories and rules be safely imported into Terraform state?
-- Should this repo provision XNLB forwarding rules or only reference platform-owned records?
+- What exact GCP permissions/project boundaries are required for the NetSec repo to provision XNLB forwarding rules and reserve public IPs?
+- What output format should the NetSec workflow provide to the requestor for the follow-on GTM onboarding API payload?
 - Who owns cluster registration when new internet-capable GKE clusters are created?
 - If no scanner-only pre-admission path exists, should scan integration be detective/remediation first rather than preventative?
 - What SLA/action should occur when a newly exposed app fails scan: notify only, block future changes, remove Palo URL category membership, or require manual exception?

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -120,14 +120,30 @@ These are the high-ticket items for stakeholder discussion.
 |------|----------|----------------|
 | **PAN-OS Terraform** | Can the provider safely manage URL categories, NAT/security policy, device groups, and commit/push? | Determines whether Option C can reduce firewall toil. |
 | **Existing Palo state** | Can current categories/rules be imported or reconciled without destructive drift? | Prevents Terraform adoption from breaking production policy. |
-| **XNLB ownership** | Does NetSec create XNLB forwarding rules, or only reference platform-created cluster records? | Defines repo scope and team ownership. |
+| **XNLB ownership** | NetSec creates and owns XNLB forwarding rules. Platform should provide/trigger the cluster registration record after building a new internet-capable GKE cluster. | Defines repo scope and team handoff. |
 | **Cluster registration** | Who creates a cluster record when a new internet-capable GKE cluster is built? | Solves the current visibility gap. |
 | **Scan gating** | Can CI require scan pass, scan ID, waiver, or manual approval before app activation? | Adds scan status without making the scanner a firewall admin. |
 | **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
-| **Scanner path** | How does the scanner reach the app before general access is opened? Can it test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE using scanner-only access? | A scan cannot be the prerequisite for opening a path the scanner cannot yet use; a private/bypass scan does not validate the internet path. |
+| **Scanner path** | The scanner likely must test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE. If no scanner-only pre-admission path exists, scanning cannot be a strict preventative gate before initial exposure. | In that case, scan integration should start as detective/remediation CI: detect failed scans after exposure, notify owners, open remediation PRs/issues, and optionally remove/revoke Palo category membership after policy-defined failure windows. |
 | **Approvals** | Who can request, approve, merge, and apply production app exposure changes? | Prevents app teams from self-approving internet access. |
 | **Revocation** | Can removing/changing an app record revoke access cleanly? | Onboarding automation must also handle decommissioning. |
 | **Secrets/state** | Where do Panorama credentials and Terraform state live, and who can access them? | Avoids creating a new privileged automation risk. |
+
+## Scanner Control Model
+
+If the scanner must use the same public FQDN path that application teams are requesting, and no scanner-only pre-admission path exists, vulnerability scanning should not be represented as a strict preventative control for initial access.
+
+Near-term scan integration should be treated as **detective/remediation CI**:
+
+```text
+app access is approved through NetSec repo
+→ public path becomes reachable
+→ scanner tests real FQDN through the production ingress chain
+→ scan result updates app record / PR status / issue
+→ failed scan triggers remediation workflow or access revocation based on policy
+```
+
+This avoids pretending scan pass can be required before the scanner has any route to the application. Preventative scan gating can be revisited later if Imperva/Cequence or another edge layer can provide scanner-only pre-admission access.
 
 ## Phased Program
 
@@ -145,8 +161,9 @@ These are the high-ticket items for stakeholder discussion.
 - Can existing Palo Alto URL categories and rules be safely imported into Terraform state?
 - Should this repo provision XNLB forwarding rules or only reference platform-owned records?
 - Who owns cluster registration when new internet-capable GKE clusters are created?
-- How does the scanner get pre-admission access without granting general public access?
-- Can Imperva/Cequence enforce scanner-only pre-admission access per app?
+- If no scanner-only pre-admission path exists, should scan integration be detective/remediation first rather than preventative?
+- What SLA/action should occur when a newly exposed app fails scan: notify only, block future changes, remove Palo URL category membership, or require manual exception?
+- Can Imperva/Cequence enforce scanner-only pre-admission access per app in the future?
 - Can origin-selection headers be made non-client-controllable?
 - What telemetry replaces Palo URL-category visibility if Option B is ever adopted?
 

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -87,14 +87,14 @@ state: requested | provisioned | active | deprecated | retired
 
 ### App admission record example
 
-Apps bind to an already-provisioned cluster ingress path by referencing `target_cluster`. The cluster record determines the Palo Alto URL category and other firewall implementation details. App records should not repeat cluster-derived firewall fields, and requestors should not choose scanner behavior. Vulnerability scan status should be produced by CI/AppSec integration as an external check or status, not supplied as app intent.
+Apps bind to an already-provisioned cluster ingress path by referencing `target_cluster`. The cluster record determines the Palo Alto URL category and other firewall implementation details. App records should not repeat cluster-derived firewall fields, and requestors should not choose scanner behavior. Vulnerability scan status should be produced by CI/AppSec integration as an external check or status, not supplied as app intent. The app record lifecycle represents desired enforcement state after review/merge: `active` means the FQDN should be admitted for the target cluster, while `revoked` means the FQDN should be removed/disabled.
 
 ```yaml
 fqdn: app.example.com
 owner: application-team
 environment: prod
 target_cluster: gke-prod-usw2-01
-state: proposed | active | revoked
+lifecycle: active | revoked
 ```
 
 ### Flow
@@ -153,7 +153,7 @@ These are the high-ticket items for stakeholder discussion.
 | **Origin trust** | Can `X-Forwarded-Origin` be stripped, overwritten, signed, or validated before Cequence uses it? | Required before Option B can be considered safe. |
 | **Scanner path** | The scanner likely must test the real public FQDN through GTM/Imperva/Cequence/XNLB/Palo/GKE. If no scanner-only pre-admission path exists, scanning cannot be a strict preventative gate before initial exposure. | In that case, scan integration should start as detective/remediation CI: detect failed scans after exposure, notify owners, open remediation PRs/issues, and optionally remove/revoke Palo category membership after policy-defined failure windows. |
 | **Approvals** | Who can request, review, merge, and apply production app exposure changes? | The app record is the proposed registration; approval should be represented by PR review/merge controls, not a vague `approval` field in the YAML. |
-| **Revocation** | Can removing/changing an app record revoke access cleanly? | Onboarding automation must also handle decommissioning. |
+| **Revocation** | Can changing an app record to `lifecycle: revoked` remove access cleanly? Can scanner findings open revocation PRs automatically? | Onboarding automation must also handle decommissioning and vulnerability-driven access removal. |
 | **Secrets/state** | Where do Panorama credentials and Terraform state live, and who can access them? | Avoids creating a new privileged automation risk. |
 
 ## Scanner Control Model
@@ -167,7 +167,7 @@ app access is approved through NetSec repo
 → public path becomes reachable
 → scanner tests real FQDN through the production ingress chain
 → scan result updates PR status / external check / issue
-→ failed scan triggers remediation workflow or access revocation based on policy
+→ failed scan triggers remediation workflow or opens a PR changing lifecycle to `revoked` based on policy
 ```
 
 This avoids pretending scan pass can be required before the scanner has any route to the application. Preventative scan gating can be revisited later if Imperva/Cequence or another edge layer can provide scanner-only pre-admission access.
@@ -206,7 +206,7 @@ Important boundary: requestors can provide the backend GKE ILB because that is t
 - What output format should the NetSec workflow provide to the requestor for the follow-on GTM onboarding API payload?
 - What exact handoff does Platform use to submit the post-build cluster intent record?
 - If no scanner-only pre-admission path exists, should scan integration be detective/remediation first rather than preventative, using external CI/AppSec checks instead of requester-supplied fields?
-- What SLA/action should occur when a newly exposed app fails scan: notify only, block future changes, remove Palo URL category membership, or require manual exception?
+- What SLA/action should occur when a newly exposed app fails scan: notify only, block future changes, open a PR setting `lifecycle: revoked`, remove Palo URL category membership, or require manual exception?
 - Can Imperva/Cequence enforce scanner-only pre-admission access per app in the future?
 - Can origin-selection headers be made non-client-controllable?
 - What telemetry replaces Palo URL-category visibility if Option B is ever adopted?

--- a/adrs/adr-gcp-internet-ingress-admission-automation.md
+++ b/adrs/adr-gcp-internet-ingress-admission-automation.md
@@ -58,7 +58,7 @@ netsec-internet-apps/
 
 ### Cluster intent record example
 
-The platform/requestor provides the backend target details. NetSec automation allocates or returns the XNLB public IP / forwarding rule output.
+The platform/requestor provides only the backend target and required metadata. NetSec automation derives Palo Alto object names, device group, URL category, NAT/security rule names, and XNLB forwarding-rule names from standards. Requestors should not provide firewall object names.
 
 ```yaml
 cluster_id: gke-prod-usw2-01
@@ -69,12 +69,13 @@ backend:
   gke_ilb_name: ilb-gke-prod-usw2-01
   gcp_project: app-prod-host-project
 netsec_ingress:
-  xnlb_forwarding_rule: fr-gke-prod-usw2-01   # created by NetSec repo
-  xnlb_vip: allocated_by_terraform           # output, not requester-selected
-  palo_device_group: dg-internet-prod
-  palo_nat_rule: nat-gke-prod-usw2-01
-  palo_security_rule: allow-edge-to-gke-prod-usw2-01
-  palo_url_category: gcp-ingress-prod-usw2-01-approved-apps
+  # derived by automation from cluster_id, environment, region, and naming standards
+  xnlb_forwarding_rule: generated_by_pipeline
+  xnlb_vip: allocated_by_terraform
+  palo_device_group: generated_by_pipeline
+  palo_nat_rule: generated_by_pipeline
+  palo_security_rule: generated_by_pipeline
+  palo_url_category: generated_by_pipeline
 allowed_edge_sources:
   - imperva_prod_nat
   - cequence_prod_nat
@@ -109,7 +110,8 @@ scan:
 
 ```text
 Platform builds GKE cluster + backend ILB
-→ Platform submits cluster intent with backend ILB details
+→ Platform submits cluster intent with backend ILB details and required metadata
+→ CI derives XNLB and Palo Alto object names from standards
 → NetSec repo provisions XNLB VIP/forwarding rule
 → NetSec repo provisions Palo NAT/security/category mapping
 → workflow outputs XNLB origin IP/name for GTM onboarding
@@ -121,7 +123,7 @@ Platform builds GKE cluster + backend ILB
 ```text
 App onboarding request
 → PR adds/updates app record targeting an existing cluster record
-→ CI validates target cluster, metadata, approval/scan/waiver state, and policy constraints
+→ CI derives target Palo category from the cluster record and validates metadata, approval/scan/waiver state, and policy constraints
 → Terraform plan shows Palo Alto URL category membership change
 → NetSec review + approval
 → Terraform apply updates Palo Alto
@@ -150,6 +152,7 @@ These are the high-ticket items for stakeholder discussion.
 | Area | Question | Why It Matters |
 |------|----------|----------------|
 | **PAN-OS Terraform** | Can the provider safely manage URL categories, NAT/security policy, device groups, and commit/push? | Determines whether Option C can reduce firewall toil. |
+| **Naming/derivation logic** | Can CI derive Palo device group, NAT/security rule names, URL category, XNLB forwarding-rule name, and origin output from cluster metadata? | Requestors should provide intent/backend data, not firewall implementation details. |
 | **Existing Palo state** | Can current categories/rules be imported or reconciled without destructive drift? | Prevents Terraform adoption from breaking production policy. |
 | **XNLB ownership** | NetSec creates and owns XNLB forwarding rules, and Option C may provision those GCP resources from the same repo that stores app/cluster intent. Platform should trigger the cluster registration workflow after building a new internet-capable GKE cluster. | Defines repo scope and team handoff. |
 | **Cluster registration** | Platform initiates the cluster record after building a new internet-capable GKE cluster; NetSec repo provisions or records the XNLB forwarding rule/public IP and Palo mapping. | Solves the current visibility gap and gives the requestor the origin IP/name required for GTM onboarding. |
@@ -190,7 +193,7 @@ For new internet-capable GKE clusters, the repository can own the cluster ingres
 7. App records can then add CNAME/FQDN membership for that cluster path.
 ```
 
-Important boundary: requestors can provide the backend GKE ILB because that is their/platform-owned target, but they should not choose the public XNLB IP directly. The XNLB public IP/forwarding rule should be allocated or returned by the NetSec workflow so the ingress path remains controlled and auditable.
+Important boundary: requestors can provide the backend GKE ILB because that is their/platform-owned target, but they should not choose the public XNLB IP, forwarding-rule name, Palo Alto device group, NAT rule, security rule, or URL category directly. Those values should be derived by the NetSec workflow from approved naming and placement standards so the ingress path remains controlled and auditable.
 
 ## Phased Program
 


### PR DESCRIPTION
## Summary
- Adds an ADR for GCP internet ingress admission automation for public GKE applications.
- Compares two options: retaining Palo Alto custom URL categories vs moving app admission to the GTM / Cequence onboarding control plane.
- Recommends GTM / Cequence admission with cluster-scoped Palo Alto allow rules as the target pattern, with Palo URL categories as the conservative fallback.

## Validation
- Markdown ADR added and committed.
- Branch pushed successfully.