### PR TITLE
Add continuous registration engine considerations

### DIFF
--- a/assessments/aws-aft-vended-custom-service-security-group-concerns.md
+++ b/assessments/aws-aft-vended-custom-service-security-group-concerns.md
@@ -168,6 +168,38 @@ Adding support for Lambda, EC2, ECS, EKS, RDS, load balancers, and other service
 
 This turns Sentinel policy into a growing AWS resource parser instead of a focused guardrail.
 
+### End-to-end Palo Alto registration needs an explicit design
+
+Cloud security group automation may be only one part of the required connectivity path.
+
+Network Security also operates a continuous registration engine that receives API requests from a Terraform provider, action, or similar integration and registers source IPs with the Palo Alto firewalls for approved destinations.
+
+Based on my current understanding, it is not yet clear how the custom security group and BYOM approach would integrate with this requirement.
+
+Under a BYOM model, each application team may need to:
+
+- know that continuous registration is required
+- add the required provider, module, or pipeline action
+- authenticate to the registration engine
+- submit the correct resource identity and destinations
+- sequence registration with resource deployment
+- update or remove registrations when the resource changes
+
+If any step is missing, the cloud resource and security group deployment may succeed while end-to-end access through the Palo Alto firewalls still fails.
+
+There is also a trust concern. An application-controlled module should not be able to register arbitrary IP addresses and destinations simply because it can call the provider. The registration path would need to validate resource ownership, account or project scope, environment, destination authorization, and registration lifecycle. Sentinel could prevent direct registration resources in governed Terraform pipelines, but the registration API would still need independent authentication and authorization.
+
+The main counterargument is that most current AWS GA services are deployed in non-routable subnets. In those paths, the Palo Alto firewalls may see the NAT gateway IP rather than an individual workload IP. The required NAT identities may be registered once during account deployment instead of requiring per-resource registration.
+
+That reduces the registration problem for those AWS paths, but it does not eliminate it for:
+
+- AWS resources deployed in general routable subnets
+- future AWS service placement changes
+- GCP environments where workload addresses are generally routable
+- flows that require workload-level source identity instead of a shared NAT identity
+
+A paved-road parent module can integrate the cloud security group and registration requirements as one developer-facing operation. It can pass the same approved connectivity intent and resource identity to the registration integration without requiring each application team to assemble the end-to-end workflow independently.
+
 ### Troubleshooting would be harder for developers
 
 A failed Sentinel policy would likely report that a security group ID, rule resource, or attachment relationship did not match a central catalog.

--- a/assessments/aws-paved-road-sentinel-policy-and-rollout-considerations.md
+++ b/assessments/aws-paved-road-sentinel-policy-and-rollout-considerations.md
@@ -77,6 +77,56 @@ The `tfconfig/v2` module call data includes:
 
 The resource data includes the module address where each resource was declared. This allows Sentinel to validate the approved caller chain without maintaining an account, environment, and security group ID catalog.
 
+## Continuous Registration Engine Enforcement
+
+Some connectivity paths also require Network Security's continuous registration engine to register source IPs with the Palo Alto firewalls for approved destinations.
+
+Where per-resource registration is required, the approved parent module should integrate registration as part of the same service deployment contract:
+
+- the parent creates the service resource
+- the nested connectivity module validates the destination and port
+- the parent attaches the governed and baseline security groups
+- the parent invokes the approved registration integration using the same resource identity and connectivity intent
+
+Sentinel should:
+
+- allow registration resources only beneath an approved service parent module
+- reject direct root-level calls to the registration provider or module
+- require approved registration module or provider versions
+- require the registration resource to share the approved parent ancestry with the service and connectivity resources
+- prevent a second independently supplied destination list from bypassing the connectivity intent already approved by the nested module
+- fail closed when registration provenance cannot be established
+
+For example, Sentinel can allow:
+
+```text
+module.lambda.module.registration.netsec_registration.this
+```
+
+It can reject:
+
+```text
+netsec_registration.this
+```
+
+Sentinel ancestry enforcement protects the governed Terraform pipeline. It does not prove that a registration request is legitimate when the API is called directly through another pipeline, script, or stolen credential.
+
+The registration API should independently:
+
+- authenticate the calling workload or workspace
+- limit the caller to its assigned AWS accounts or GCP projects
+- validate that the resource exists and belongs to the caller's scope
+- derive or verify the current IP addresses from authoritative cloud APIs
+- validate the destination against approved connectivity intent
+- maintain an audit trail
+- expire or remove stale registrations
+
+Terraform is suitable for declaring the resource identity and connectivity intent. The continuous registration engine should reconcile live IP changes after the Terraform run, including ENI replacement, scaling, failover, and resource deletion.
+
+For AWS services in non-routable subnets, AFT may be able to register the account's NAT gateway identities during account deployment. Per-resource registration may not be required when the Palo Alto firewalls see only those NAT identities.
+
+That account-level model should not be assumed for general routable AWS subnets, future placement changes, or GCP environments where workload addresses are routed to the inspection path.
+
 ## Policy Rollout and Migration
 
 The enforcement should not be introduced as one hard-mandatory policy covering every existing service resource, security group rule, and attachment on day one.
@@ -95,6 +145,8 @@ The following policies can be hard mandatory when the new module ecosystem is in
 - require the connectivity module to be called from beneath an approved service parent module source
 - require approved parent and connectivity module versions
 - require security group resources created by the connectivity module to have the complete approved parent and nested module ancestry
+- reject direct calls to the continuous registration provider or module where per-resource registration is required
+- require registration resources to share the approved parent ancestry and connectivity intent
 - fail closed when a run attempts to use the connectivity module but its caller provenance cannot be established
 
 These policies do not require existing workspaces to already use the paved road. They prevent the new connectivity module from being consumed incorrectly from the beginning.


### PR DESCRIPTION
## Summary

- adds the continuous registration engine as an end-to-end dependency in the AFT custom security group assessment
- documents BYOM integration and trust concerns
- acknowledges the NAT gateway registration counterargument for current non-routable AWS paths
- covers routable AWS and GCP cases
- adds Sentinel ancestry, API authorization, and registration lifecycle considerations to the companion policy document